### PR TITLE
Change name as per Google feedback

### DIFF
--- a/extension.yaml
+++ b/extension.yaml
@@ -2,7 +2,7 @@ name: revenuecat-firebase-extension
 version: 0.0.1
 specVersion: v1beta  # Firebase Extensions specification version (do not edit)
 
-displayName: Make In-App Purchases with RevenueCat
+displayName: Enable In-App Purchases with RevenueCat
 description: Facilitates in-app purchases and subscriptions, controls access to premium content, and syncs purchase information to Firestore.
 
 license: apache-2.0


### PR DESCRIPTION
Changing the extension name from `Add In-App Purchases with RevenueCat` to `Make In-App Purchases with RevenueCat`