### PR TITLE
chore: added prepare script

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -1,6 +1,7 @@
 {
   "name": "functions",
   "scripts": {
+    "prepare": "npm run build",
     "lint": "eslint --ext .js,.ts .",
     "test": "jest --watchAll=false --verbose=false",
     "signer": "ts-node development/signer-server.ts",


### PR DESCRIPTION
Source files are ignored in the .gitignore and can be built without issue for local development.

For `production`, a `prepare` script is needed to build the source files when installing the extension.