### PR TITLE
Correctly update the Customers collection when removing promotionals

### DIFF
--- a/functions/src/__tests__/events.test.ts
+++ b/functions/src/__tests__/events.test.ts
@@ -4,236 +4,380 @@ import * as admin from "firebase-admin";
 import moment from "moment";
 
 function timeout(ms: number) {
-    return new Promise(resolve => setTimeout(resolve, ms));
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 describe("events", () => {
+  // @ts-ignore
+  beforeAll(() => global.firebaseTest.cleanup());
+
+  afterEach(() => {
     // @ts-ignore
-    beforeAll(() => global.firebaseTest.cleanup());
+    global.firebaseTest.cleanup();
+  });
 
-    afterEach(() => {
-        // @ts-ignore
-        global.firebaseTest.cleanup();
-    });
-
-    const validPayload = { api_version: "0.0.2", event: { id: "uuid", app_user_id: "chairman_carranza", bar: "baz", aliases: ["miguelcarranza", "chairman_carranza"] }, customer_info: { original_app_user_id: "miguelcarranza", first_seen: "2022-01-01 15:03", entitlements: {
+  const validPayload = {
+    api_version: "0.0.2",
+    event: {
+      id: "uuid",
+      app_user_id: "chairman_carranza",
+      bar: "baz",
+      aliases: ["miguelcarranza", "chairman_carranza"],
+    },
+    customer_info: {
+      original_app_user_id: "miguelcarranza",
+      first_seen: "2022-01-01 15:03",
+      entitlements: {
         pro: {
-            expires_date: moment.utc().add("days", 2).format()
+          expires_date: moment.utc().add("days", 2).format(),
         },
         expired: {
-            expires_date: moment.utc().subtract("days", 2).format()
+          expires_date: moment.utc().subtract("days", 2).format(),
         },
         lifetime: {
-            expires_date: null
-        }
-    } } };
+          expires_date: null,
+        },
+      },
+    },
+  };
 
-    it("API returns extension version in headers", async () => {
-        const mockedResponse = getMockedResponse(expect, () => Promise.resolve())(200, {}) as any;
-        const mockedRequest = getMockedRequest(createJWT(60, validPayload, "test_secret")) as any;
-        await api.handler(mockedRequest, mockedResponse);
+  it("API returns extension version in headers", async () => {
+    const mockedResponse = getMockedResponse(expect, () => Promise.resolve())(
+      200,
+      {}
+    ) as any;
+    const mockedRequest = getMockedRequest(
+      createJWT(60, validPayload, "test_secret")
+    ) as any;
+    await api.handler(mockedRequest, mockedResponse);
 
-        expect(mockedResponse.getHeaders()).toEqual({ 'X-EXTENSION-VERSION': validPayload.api_version });
+    expect(mockedResponse.getHeaders()).toEqual({
+      "X-EXTENSION-VERSION": validPayload.api_version,
+    });
+  });
+
+  it("saves the event in the configured events collection", async () => {
+    const mockedResponse = getMockedResponse(expect, () => Promise.resolve())(
+      200,
+      {}
+    ) as any;
+
+    const mockedRequest = getMockedRequest(
+      createJWT(60, validPayload, "test_secret")
+    ) as any;
+
+    api.handler(mockedRequest, mockedResponse);
+
+    await timeout(300);
+
+    const doc = await admin
+      .firestore()
+      .collection("revenuecat_events")
+      .doc("uuid")
+      .get();
+    expect(doc.data()).toEqual(validPayload.event);
+  });
+
+  it("doesn't save the event if the REVENUECAT_EVENTS_COLLECTION setting is not set", async () => {
+    jest.resetModules();
+    const originalProcessEnv = process.env;
+    process.env = {
+      ...originalProcessEnv,
+      REVENUECAT_EVENTS_COLLECTION: "",
+    };
+
+    const { handler } = require("../index");
+
+    const mockedResponse = getMockedResponse(expect, () => Promise.resolve())(
+      200,
+      {}
+    ) as any;
+    const mockedRequest = getMockedRequest(
+      createJWT(
+        60,
+        {
+          ...validPayload,
+          event: { ...validPayload.event, id: "not_save_this" },
+        },
+        "test_secret"
+      )
+    ) as any;
+
+    handler(mockedRequest, mockedResponse);
+
+    await timeout(300);
+
+    const doc = await admin
+      .firestore()
+      .collection("revenuecat_events")
+      .doc("not_save_this")
+      .get();
+    expect(doc.data()).toEqual(undefined);
+
+    process.env = originalProcessEnv;
+  });
+
+  it("saves the customer_info in the customer collection", async () => {
+    const mockedResponse = getMockedResponse(expect, () => Promise.resolve())(
+      200,
+      {}
+    ) as any;
+    const mockedRequest = getMockedRequest(
+      createJWT(60, validPayload, "test_secret")
+    ) as any;
+
+    api.handler(mockedRequest, mockedResponse);
+
+    await timeout(500);
+
+    const doc = await admin
+      .firestore()
+      .collection("revenuecat_customers")
+      .doc("chairman_carranza")
+      .get();
+    expect(doc.data()).toEqual({
+      ...validPayload.customer_info,
+      aliases: ["miguelcarranza", "chairman_carranza"],
     });
 
-    it("saves the event in the configured events collection", async () => {
-        const mockedResponse = getMockedResponse(expect, () => Promise.resolve())(200, {}) as any;
-        
-        const mockedRequest = getMockedRequest(createJWT(60, validPayload, "test_secret")) as any;
+    const additionalCustomerInfo = {
+      original_app_user_id: "chairman_carranza",
+      another_field: "baz",
+    };
 
-        api.handler(mockedRequest, mockedResponse);
+    const otherMockedRequest = getMockedRequest(
+      createJWT(
+        60,
+        { ...validPayload, customer_info: additionalCustomerInfo },
+        "test_secret"
+      )
+    ) as any;
 
-        await timeout(300);
+    api.handler(otherMockedRequest, mockedResponse);
 
-        const doc = await admin.firestore().collection("revenuecat_events").doc("uuid").get();
-        expect(doc.data()).toEqual(validPayload.event);
+    await timeout(500);
+
+    const updatedDoc = await admin
+      .firestore()
+      .collection("revenuecat_customers")
+      .doc("chairman_carranza")
+      .get();
+    expect(updatedDoc.data()).toEqual({
+      ...validPayload.customer_info,
+      ...additionalCustomerInfo,
+      aliases: ["miguelcarranza", "chairman_carranza"],
     });
+  });
 
-    it("doesn't save the event if the REVENUECAT_EVENTS_COLLECTION setting is not set", async () => {
-        jest.resetModules();
-        const originalProcessEnv = process.env;
-        process.env = {
-            ...originalProcessEnv,
-            REVENUECAT_EVENTS_COLLECTION: ""
-        }
+  it("doesn't save the event if the REVENUECAT_CUSTOMERS_COLLECTION setting is not set", async () => {
+    jest.resetModules();
+    const originalProcessEnv = process.env;
+    process.env = {
+      ...originalProcessEnv,
+      REVENUECAT_CUSTOMERS_COLLECTION: "",
+    };
 
-        const { handler } = require("../index")
+    const { handler } = require("../index");
 
-        const mockedResponse = getMockedResponse(expect, () => Promise.resolve())(200, {}) as any;
-        const mockedRequest = getMockedRequest(createJWT(60, {...validPayload, event: {...validPayload.event, id: "not_save_this"}}, "test_secret")) as any;
-
-        handler(mockedRequest, mockedResponse);
-
-        await timeout(300);
-
-        const doc = await admin.firestore().collection("revenuecat_events").doc("not_save_this").get();
-        expect(doc.data()).toEqual(undefined);
-
-        process.env = originalProcessEnv;
-    });
-
-    it("saves the customer_info in the customer collection", async () => {
-        const mockedResponse = getMockedResponse(expect, () => Promise.resolve())(200, {}) as any;
-        const mockedRequest = getMockedRequest(createJWT(60, validPayload, "test_secret")) as any;
-
-        api.handler(mockedRequest, mockedResponse);
-
-        await timeout(500);
-
-        const doc = await admin.firestore().collection("revenuecat_customers").doc("chairman_carranza").get();
-        expect(doc.data()).toEqual({...validPayload.customer_info, aliases: ["miguelcarranza", "chairman_carranza"] });
-
-        const additionalCustomerInfo = { original_app_user_id: "chairman_carranza", another_field: "baz" };
-
-        const otherMockedRequest = getMockedRequest(createJWT(60, {...validPayload, customer_info: additionalCustomerInfo }, "test_secret")) as any;
-
-        api.handler(otherMockedRequest, mockedResponse);
-
-        await timeout(500);
-
-        const updatedDoc = await admin.firestore().collection("revenuecat_customers").doc("chairman_carranza").get();
-        expect(updatedDoc.data()).toEqual({...validPayload.customer_info, ...additionalCustomerInfo, aliases: ["miguelcarranza", "chairman_carranza"] });
-    });
-
-    it("doesn't save the event if the REVENUECAT_CUSTOMERS_COLLECTION setting is not set", async () => {
-        jest.resetModules();
-        const originalProcessEnv = process.env;
-        process.env = {
-            ...originalProcessEnv,
-            REVENUECAT_CUSTOMERS_COLLECTION: ""
-        }
-
-        const { handler } = require("../index")
-
-        const mockedResponse = getMockedResponse(expect, () => Promise.resolve())(200, {}) as any;
-        const mockedRequest = getMockedRequest(createJWT(60, { ...validPayload, customer_info: { ...validPayload.customer_info, original_app_user_id: "not_save_this" } }, "test_secret")) as any;
-
-        handler(mockedRequest, mockedResponse);
-
-        await timeout(300);
-
-        const doc = await admin.firestore().collection("revenuecat_customers").doc("not_save_this").get();
-        expect(doc.data()).toEqual(undefined);
-
-        process.env = originalProcessEnv;
-    });
-
-    it("doesn't save the event if the REVENUECAT_CUSTOMERS_COLLECTION setting without a userid", async () => {
-        jest.resetModules();
-        const originalProcessEnv = process.env;
-        process.env = {
-            ...originalProcessEnv,
-            REVENUECAT_CUSTOMERS_COLLECTION: "customers"
-        }
-
-        const { handler } = require("../index")
-
-        const mockedResponse = getMockedResponse(expect, () => Promise.resolve())(200, {}) as any;
-        const mockedRequest = getMockedRequest(createJWT(60, { ...validPayload, app_user_id: null, customer_info: { ...validPayload.customer_info, original_app_user_id: "not_save_this" } }, "test_secret")) as any;
-
-        handler(mockedRequest, mockedResponse);
-
-        await timeout(300);
-
-        const doc = await admin.firestore().collection("revenuecat_customers").doc("not_save_this").get();
-        expect(doc.data()).toEqual(undefined);
-
-        process.env = originalProcessEnv;
-    });
-
-    it("set custom claims for user if SET_CUSTOM_CLAIMS is set", async () => {
-        const testUserId = validPayload.event.app_user_id;
-
-        jest.resetModules();
-        const originalProcessEnv = process.env;
-        process.env = {
-            ...originalProcessEnv,
-            SET_CUSTOM_CLAIMS: "ENABLED"
-        }
-
-        const { handler } = require("../index")
-
-        const auth = admin.auth();
-
-        const userImportRecords = [
-            {
-              uid: testUserId,
-              email: 'user1@example.com',
-              passwordHash: Buffer.from('passwordHash1'),
-              passwordSalt: Buffer.from('salt1'),
-            },
-            {
-              uid: 'leaveThisUserAlone',
-              email: 'user2@example.com',
-              passwordHash: Buffer.from('passwordHash2'),
-              passwordSalt: Buffer.from('salt2'),
-            },
-          ];
-
-        await auth.importUsers(userImportRecords, {
-          hash: {
-            algorithm: 'HMAC_SHA256',
-            key: Buffer.from('secretKey'),
+    const mockedResponse = getMockedResponse(expect, () => Promise.resolve())(
+      200,
+      {}
+    ) as any;
+    const mockedRequest = getMockedRequest(
+      createJWT(
+        60,
+        {
+          ...validPayload,
+          customer_info: {
+            ...validPayload.customer_info,
+            original_app_user_id: "not_save_this",
           },
-        });
+        },
+        "test_secret"
+      )
+    ) as any;
 
-        await timeout(100);
+    handler(mockedRequest, mockedResponse);
 
-        const mockedResponse = getMockedResponse(expect, () => Promise.resolve())(200, {}) as any;
-        const mockedRequest = getMockedRequest(createJWT(60, {...validPayload, customer_info: {...validPayload.customer_info, original_app_user_id: testUserId}}, "test_secret")) as any;
+    await timeout(300);
 
-        handler(mockedRequest, mockedResponse);
+    const doc = await admin
+      .firestore()
+      .collection("revenuecat_customers")
+      .doc("not_save_this")
+      .get();
+    expect(doc.data()).toEqual(undefined);
 
-        await timeout(500);
+    process.env = originalProcessEnv;
+  });
 
-        const { customClaims } = await auth.getUser(testUserId);
+  it("doesn't save the event if the REVENUECAT_CUSTOMERS_COLLECTION setting without a userid", async () => {
+    jest.resetModules();
+    const originalProcessEnv = process.env;
+    process.env = {
+      ...originalProcessEnv,
+      REVENUECAT_CUSTOMERS_COLLECTION: "customers",
+    };
 
-        expect(customClaims).toEqual({revenueCatEntitlements: ["pro", "lifetime"]});
+    const { handler } = require("../index");
 
-        const { customClaims: anotherCustomClaims } = await auth.getUser("leaveThisUserAlone");
-
-        expect(anotherCustomClaims).toEqual(undefined);
-    });
-
-    it("fails gracefully seting custom claims for user if SET_CUSTOM_CLAIMS is set but user doesn't exist", async () => {
-        const testUserId = 'francisco';
-
-        jest.resetModules();
-        const originalProcessEnv = process.env;
-        process.env = {
-            ...originalProcessEnv,
-            SET_CUSTOM_CLAIMS: "ENABLED"
-        }
-
-        const { handler } = require("../index")
-
-        const auth = admin.auth();
-
-        const userImportRecords = [
-            {
-              uid: testUserId,
-              email: 'user1@example.com',
-              passwordHash: Buffer.from('passwordHash1'),
-              passwordSalt: Buffer.from('salt1'),
-            },
-          ];
-
-        await auth.importUsers(userImportRecords, {
-          hash: {
-            algorithm: 'HMAC_SHA256',
-            key: Buffer.from('secretKey'),
+    const mockedResponse = getMockedResponse(expect, () => Promise.resolve())(
+      200,
+      {}
+    ) as any;
+    const mockedRequest = getMockedRequest(
+      createJWT(
+        60,
+        {
+          ...validPayload,
+          app_user_id: null,
+          customer_info: {
+            ...validPayload.customer_info,
+            original_app_user_id: "not_save_this",
           },
-        });
+        },
+        "test_secret"
+      )
+    ) as any;
 
-        await timeout(100);
+    handler(mockedRequest, mockedResponse);
 
-        const mockedResponse = getMockedResponse(expect, (resp) => {
-            expect(resp).toEqual({});            
-        })(200, {}) as any;
+    await timeout(300);
 
-        const mockedRequest = getMockedRequest(createJWT(60, {...validPayload, customer_info: {...validPayload.customer_info, original_app_user_id: "doesntExist"}}, "test_secret")) as any;
+    const doc = await admin
+      .firestore()
+      .collection("revenuecat_customers")
+      .doc("not_save_this")
+      .get();
+    expect(doc.data()).toEqual(undefined);
 
-        await handler(mockedRequest, mockedResponse);
-        await timeout(500);
+    process.env = originalProcessEnv;
+  });
+
+  it("set custom claims for user if SET_CUSTOM_CLAIMS is set", async () => {
+    const testUserId = validPayload.event.app_user_id;
+
+    jest.resetModules();
+    const originalProcessEnv = process.env;
+    process.env = {
+      ...originalProcessEnv,
+      SET_CUSTOM_CLAIMS: "ENABLED",
+    };
+
+    const { handler } = require("../index");
+
+    const auth = admin.auth();
+
+    const userImportRecords = [
+      {
+        uid: testUserId,
+        email: "user1@example.com",
+        passwordHash: Buffer.from("passwordHash1"),
+        passwordSalt: Buffer.from("salt1"),
+      },
+      {
+        uid: "leaveThisUserAlone",
+        email: "user2@example.com",
+        passwordHash: Buffer.from("passwordHash2"),
+        passwordSalt: Buffer.from("salt2"),
+      },
+    ];
+
+    await auth.importUsers(userImportRecords, {
+      hash: {
+        algorithm: "HMAC_SHA256",
+        key: Buffer.from("secretKey"),
+      },
     });
+
+    await timeout(100);
+
+    const mockedResponse = getMockedResponse(expect, () => Promise.resolve())(
+      200,
+      {}
+    ) as any;
+    const mockedRequest = getMockedRequest(
+      createJWT(
+        60,
+        {
+          ...validPayload,
+          customer_info: {
+            ...validPayload.customer_info,
+            original_app_user_id: testUserId,
+          },
+        },
+        "test_secret"
+      )
+    ) as any;
+
+    handler(mockedRequest, mockedResponse);
+
+    await timeout(500);
+
+    const { customClaims } = await auth.getUser(testUserId);
+
+    expect(customClaims).toEqual({
+      revenueCatEntitlements: ["pro", "lifetime"],
+    });
+
+    const { customClaims: anotherCustomClaims } = await auth.getUser(
+      "leaveThisUserAlone"
+    );
+
+    expect(anotherCustomClaims).toEqual(undefined);
+  });
+
+  it("fails gracefully seting custom claims for user if SET_CUSTOM_CLAIMS is set but user doesn't exist", async () => {
+    const testUserId = "francisco";
+
+    jest.resetModules();
+    const originalProcessEnv = process.env;
+    process.env = {
+      ...originalProcessEnv,
+      SET_CUSTOM_CLAIMS: "ENABLED",
+    };
+
+    const { handler } = require("../index");
+
+    const auth = admin.auth();
+
+    const userImportRecords = [
+      {
+        uid: testUserId,
+        email: "user1@example.com",
+        passwordHash: Buffer.from("passwordHash1"),
+        passwordSalt: Buffer.from("salt1"),
+      },
+    ];
+
+    await auth.importUsers(userImportRecords, {
+      hash: {
+        algorithm: "HMAC_SHA256",
+        key: Buffer.from("secretKey"),
+      },
+    });
+
+    await timeout(100);
+
+    const mockedResponse = getMockedResponse(expect, (resp) => {
+      expect(resp).toEqual({});
+    })(200, {}) as any;
+
+    const mockedRequest = getMockedRequest(
+      createJWT(
+        60,
+        {
+          ...validPayload,
+          customer_info: {
+            ...validPayload.customer_info,
+            original_app_user_id: "doesntExist",
+          },
+        },
+        "test_secret"
+      )
+    ) as any;
+
+    await handler(mockedRequest, mockedResponse);
+    await timeout(500);
+  });
 });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -74,12 +74,12 @@ export const handler = functions.https.onRequest(async (request, response) => {
 
     if (CUSTOMERS_COLLECTION && userId) {
       const customersCollection = firestore.collection(CUSTOMERS_COLLECTION);
+
       await customersCollection.doc(userId).set(
         {
           ...customerPayload,
           aliases: eventPayload.aliases,
-        },
-        { merge: true }
+        }
       );
     }
 


### PR DESCRIPTION
Fix: https://github.com/RevenueCat/firestore-revenuecat-purchases/issues/33

When a promotional is removed, both the `Subscription` and `Entitlement` object are not present anymore in the Request payload.

Since we are using `{ merge: true}` when calling `.set()`, existing keys will remain in the collection.

Merge doesn't actually make sense since `customer_info` will always contain the most up to date version of the `subscriber_info` as per our API. So we should always overwrite

Note: Review by commit is better, as I ran `prettier` on the test file. We'll have to add a CI and prettier to the whole project at some point.