### PR TITLE
Fix incorrect data in customers collection after removing promotionals + Allow subcollections 

### DIFF
--- a/extension.yaml
+++ b/extension.yaml
@@ -102,6 +102,10 @@ params:
       This can be the location of an existing user collection, the extension will not overwrite your existing data but rather merge the RevenueCat data into your existing firestore documents.
       Leave empty if you do not want the extension to store RevenueCat customer details.
 
+      It supports placeholders for app_user_id, for example:
+      /users/{app_user_id}/purchaser-info
+      Will save the purchaser-info on a document named also "{app_user_id}" under the subcollection "purchaser-info"
+
       (You can later modify this value in Google Firestore > Extensions > Extension Configuration > Reconfigure extension)
     validationRegex: "^[^/]+(/[^/]+/[^/]+)*$"
     validationErrorMessage: Firestore collection paths must be an odd number of segments separated by slashes, e.g. "path/to/collection".

--- a/extension.yaml
+++ b/extension.yaml
@@ -103,7 +103,7 @@ params:
       Leave empty if you do not want the extension to store RevenueCat customer details.
 
       It supports placeholders for app_user_id, for example:
-      /users/{app_user_id}/purchaser-info
+      users/{app_user_id}/purchaser-info
       Will save the purchaser-info on a document named also "{app_user_id}" under the subcollection "purchaser-info"
 
       (You can later modify this value in Google Firestore > Extensions > Extension Configuration > Reconfigure extension)

--- a/functions/src/__tests__/authentication.test.ts
+++ b/functions/src/__tests__/authentication.test.ts
@@ -35,7 +35,7 @@ describe("authentication", () => {
         const mockedRequest = getMockedRequest(createJWT(60, payload, "invalid_secret")) as any;
 
         api.handler(mockedRequest, mockedResponse);
-    });    
+    });
 
     it("should not authenticate with an invalid payload", (done) => {
         const mockedResponse = getMockedResponse(expect, () => done())(401, EXPECTED_AUTH_ERROR) as any;

--- a/functions/src/__tests__/events.test.ts
+++ b/functions/src/__tests__/events.test.ts
@@ -3,7 +3,7 @@ import * as api from "../index";
 import * as admin from "firebase-admin";
 import moment from "moment";
 
-function timeout(ms: number) {
+function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
@@ -27,6 +27,44 @@ describe("events", () => {
     customer_info: {
       original_app_user_id: "miguelcarranza",
       first_seen: "2022-01-01 15:03",
+      subscriptions: {
+        pro: {
+          purchase_date: moment.utc().subtract("days", 28).format(),
+          expires_date: moment.utc().add("days", 2).format(),
+          period_type: "normal",
+          original_purchase_date: moment.utc().subtract("days", 28).format(),
+          store: "app_store",
+          is_sandbox: true,
+          unsubscribe_detected_at: null,
+          billing_issues_detected_at: null,
+          grace_period_expires_date: null,
+          ownership_type: "PURCHASED",
+        },
+        expired: {
+          purchase_date: moment.utc().subtract("days", 32).format(),
+          expires_date: moment.utc().subtract("days", 2).format(),
+          period_type: "normal",
+          original_purchase_date: moment.utc().subtract("days", 32).format(),
+          store: "app_store",
+          is_sandbox: true,
+          unsubscribe_detected_at: moment.utc().subtract("days", 5).format(),
+          billing_issues_detected_at: null,
+          grace_period_expires_date: null,
+          ownership_type: "PURCHASED",
+        },
+        lifetime: {
+          purchase_date: moment.utc().subtract("days", 32).format(),
+          expires_date: null,
+          period_type: "normal",
+          original_purchase_date: moment.utc().subtract("days", 32).format(),
+          store: "app_store",
+          is_sandbox: true,
+          unsubscribe_detected_at: null,
+          billing_issues_detected_at: null,
+          grace_period_expires_date: null,
+          ownership_type: "PURCHASED",
+        },
+      },
       entitlements: {
         pro: {
           expires_date: moment.utc().add("days", 2).format(),
@@ -68,7 +106,7 @@ describe("events", () => {
 
     api.handler(mockedRequest, mockedResponse);
 
-    await timeout(300);
+    await sleep(300);
 
     const doc = await admin
       .firestore()
@@ -105,7 +143,7 @@ describe("events", () => {
 
     handler(mockedRequest, mockedResponse);
 
-    await timeout(300);
+    await sleep(300);
 
     const doc = await admin
       .firestore()
@@ -118,6 +156,12 @@ describe("events", () => {
   });
 
   it("saves the customer_info in the customer collection", async () => {
+    await admin
+      .firestore()
+      .collection("revenuecat_customers")
+      .doc("chairman_carranza")
+      .delete();
+
     const mockedResponse = getMockedResponse(expect, () => Promise.resolve())(
       200,
       {}
@@ -128,7 +172,7 @@ describe("events", () => {
 
     api.handler(mockedRequest, mockedResponse);
 
-    await timeout(500);
+    await sleep(500);
 
     const doc = await admin
       .firestore()
@@ -148,14 +192,20 @@ describe("events", () => {
     const otherMockedRequest = getMockedRequest(
       createJWT(
         60,
-        { ...validPayload, customer_info: additionalCustomerInfo },
+        {
+          ...validPayload,
+          customer_info: {
+            ...validPayload.customer_info,
+            ...additionalCustomerInfo,
+          },
+        },
         "test_secret"
       )
     ) as any;
 
     api.handler(otherMockedRequest, mockedResponse);
 
-    await timeout(500);
+    await sleep(500);
 
     const updatedDoc = await admin
       .firestore()
@@ -169,7 +219,135 @@ describe("events", () => {
     });
   });
 
+  it("removes entitlements/subscriptions from the customer collection", async () => {
+    await admin
+      .firestore()
+      .collection("revenuecat_customers")
+      .doc("chairman_carranza")
+      .delete();
+
+    const initialPayload = {
+      ...validPayload,
+      customer_info: {
+        ...validPayload.customer_info,
+        subscriptions: {
+          ...validPayload.customer_info.subscriptions,
+          promotional: {
+            purchase_date: moment.utc().subtract("days", 28).format(),
+            expires_date: moment.utc().add("days", 2).format(),
+            period_type: "normal",
+            original_purchase_date: moment.utc().subtract("days", 28).format(),
+            store: "promotional",
+            is_sandbox: false,
+            unsubscribe_detected_at: null,
+            billing_issues_detected_at: null,
+            grace_period_expires_date: null,
+          },
+        },
+        entitlements: {
+          ...validPayload.customer_info.entitlements,
+          promotional: {
+            expires_date: moment.utc().add("days", 4).format(),
+          },
+        },
+      },
+    };
+
+    const mockedResponse = getMockedResponse(expect, () => Promise.resolve())(
+      200,
+      {}
+    ) as any;
+    const mockedRequest = getMockedRequest(
+      createJWT(60, initialPayload, "test_secret")
+    ) as any;
+
+    api.handler(mockedRequest, mockedResponse);
+
+    await sleep(500);
+
+    const doc = await admin
+      .firestore()
+      .collection("revenuecat_customers")
+      .doc("chairman_carranza")
+      .get();
+
+    expect(doc.data()).toEqual({
+      ...initialPayload.customer_info,
+      aliases: ["miguelcarranza", "chairman_carranza"],
+    });
+
+    const otherMockedRequest = getMockedRequest(
+      createJWT(
+        60,
+        // When promotionals are removed, neither customer_info nor subscriptions will contain them anymore
+        validPayload,
+        "test_secret"
+      )
+    ) as any;
+
+    api.handler(otherMockedRequest, mockedResponse);
+
+    await sleep(500);
+
+    const updatedDoc = await admin
+      .firestore()
+      .collection("revenuecat_customers")
+      .doc("chairman_carranza")
+      .get();
+    expect(updatedDoc.data()).toEqual({
+      ...validPayload.customer_info,
+      aliases: ["miguelcarranza", "chairman_carranza"],
+    });
+  });
+
+  it("does not overwrite other keys of an existing collection", async () => {
+    await admin
+      .firestore()
+      .collection("revenuecat_customers")
+      .doc("chairman_carranza")
+      .delete();
+
+    await admin
+      .firestore()
+      .collection("revenuecat_customers")
+      .doc("chairman_carranza")
+      .set({
+        email: "chairman@revenuecat.com",
+      });
+
+    const mockedResponse = getMockedResponse(expect, () => Promise.resolve())(
+      200,
+      {}
+    ) as any;
+
+    const mockedRequest = getMockedRequest(
+      createJWT(60, validPayload, "test_secret")
+    ) as any;
+
+    api.handler(mockedRequest, mockedResponse);
+
+    await sleep(300);
+
+    const doc = await admin
+      .firestore()
+      .collection("revenuecat_customers")
+      .doc("chairman_carranza")
+      .get();
+
+    expect(doc.data()).toEqual({
+      ...validPayload.customer_info,
+      email: "chairman@revenuecat.com",
+      aliases: validPayload.event.aliases,
+    });
+  });
+
   it("handles ID placeholders in customer collection parameter", async () => {
+    await admin
+      .firestore()
+      .collection("revenuecat_customers")
+      .doc("chairman_carranza")
+      .delete();
+
     jest.resetModules();
     const originalProcessEnv = process.env;
     process.env = {
@@ -189,7 +367,7 @@ describe("events", () => {
 
     handler(mockedRequest, mockedResponse);
 
-    await timeout(500);
+    await sleep(500);
 
     const doc = await admin
       .firestore()
@@ -204,33 +382,6 @@ describe("events", () => {
       aliases: ["miguelcarranza", "chairman_carranza"],
     });
 
-    const additionalCustomerInfo = {
-      original_app_user_id: "chairman_carranza",
-      another_field: "baz",
-    };
-
-    const otherMockedRequest = getMockedRequest(
-      createJWT(
-        60,
-        { ...validPayload, customer_info: additionalCustomerInfo },
-        "test_secret"
-      )
-    ) as any;
-
-    handler(otherMockedRequest, mockedResponse);
-
-    await timeout(500);
-
-    const updatedDoc = await admin
-      .firestore()
-      .collection("revenuecat_customers")
-      .doc("chairman_carranza")
-      .get();
-    expect(updatedDoc.data()).toEqual({
-      ...validPayload.customer_info,
-      ...additionalCustomerInfo,
-      aliases: ["miguelcarranza", "chairman_carranza"],
-    });
     process.env = originalProcessEnv;
   });
 
@@ -264,7 +415,7 @@ describe("events", () => {
 
     handler(mockedRequest, mockedResponse);
 
-    await timeout(300);
+    await sleep(300);
 
     const doc = await admin
       .firestore()
@@ -307,7 +458,7 @@ describe("events", () => {
 
     handler(mockedRequest, mockedResponse);
 
-    await timeout(300);
+    await sleep(300);
 
     const doc = await admin
       .firestore()
@@ -355,7 +506,7 @@ describe("events", () => {
       },
     });
 
-    await timeout(100);
+    await sleep(100);
 
     const mockedResponse = getMockedResponse(expect, () => Promise.resolve())(
       200,
@@ -377,7 +528,7 @@ describe("events", () => {
 
     handler(mockedRequest, mockedResponse);
 
-    await timeout(500);
+    await sleep(500);
 
     const { customClaims } = await auth.getUser(testUserId);
 
@@ -423,7 +574,7 @@ describe("events", () => {
       },
     });
 
-    await timeout(100);
+    await sleep(100);
 
     const mockedResponse = getMockedResponse(expect, (resp) => {
       expect(resp).toEqual({});
@@ -444,7 +595,7 @@ describe("events", () => {
     ) as any;
 
     await handler(mockedRequest, mockedResponse);
-    await timeout(500);
+    await sleep(500);
     process.env = originalProcessEnv;
   });
 });

--- a/functions/src/__tests__/events.test.ts
+++ b/functions/src/__tests__/events.test.ts
@@ -4,236 +4,380 @@ import * as admin from "firebase-admin";
 import moment from "moment";
 
 function timeout(ms: number) {
-    return new Promise(resolve => setTimeout(resolve, ms));
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 describe("events", () => {
+  // @ts-ignore
+  beforeAll(() => global.firebaseTest.cleanup());
+
+  afterEach(() => {
     // @ts-ignore
-    beforeAll(() => global.firebaseTest.cleanup());
+    global.firebaseTest.cleanup();
+  });
 
-    afterEach(() => {
-        // @ts-ignore
-        global.firebaseTest.cleanup();
-    });
-
-    const validPayload = { api_version: "0.0.2", event: { id: "uuid", app_user_id: "chairman_carranza", bar: "baz", aliases: ["miguelcarranza", "chairman_carranza"] }, customer_info: { original_app_user_id: "miguelcarranza", first_seen: "2022-01-01 15:03", entitlements: {
+  const validPayload = {
+    api_version: "0.0.2",
+    event: {
+      id: "uuid",
+      app_user_id: "chairman_carranza",
+      bar: "baz",
+      aliases: ["miguelcarranza", "chairman_carranza"],
+    },
+    customer_info: {
+      original_app_user_id: "miguelcarranza",
+      first_seen: "2022-01-01 15:03",
+      entitlements: {
         pro: {
-            expires_date: moment.utc().add("days", 2).format()
+          expires_date: moment.utc().add("days", 2).format(),
         },
         expired: {
-            expires_date: moment.utc().subtract("days", 2).format()
+          expires_date: moment.utc().subtract("days", 2).format(),
         },
         lifetime: {
-            expires_date: null
-        }
-    } } };
+          expires_date: null,
+        },
+      },
+    },
+  };
 
-    it("API returns extension version in headers", async () => {
-        const mockedResponse = getMockedResponse(expect, () => Promise.resolve())(200, {}) as any;
-        const mockedRequest = getMockedRequest(createJWT(60, validPayload, "test_secret")) as any;
-        await api.handler(mockedRequest, mockedResponse);
+  it("API returns extension version in headers", async () => {
+    const mockedResponse = getMockedResponse(expect, () => Promise.resolve())(
+      200,
+      {}
+    ) as any;
+    const mockedRequest = getMockedRequest(
+      createJWT(60, validPayload, "test_secret")
+    ) as any;
+    await api.handler(mockedRequest, mockedResponse);
 
-        expect(mockedResponse.getHeaders()).toEqual({ 'X-EXTENSION-VERSION': validPayload.api_version });
+    expect(mockedResponse.getHeaders()).toEqual({
+      "X-EXTENSION-VERSION": validPayload.api_version,
+    });
+  });
+
+  it("saves the event in the configured events collection", async () => {
+    const mockedResponse = getMockedResponse(expect, () => Promise.resolve())(
+      200,
+      {}
+    ) as any;
+
+    const mockedRequest = getMockedRequest(
+      createJWT(60, validPayload, "test_secret")
+    ) as any;
+
+    api.handler(mockedRequest, mockedResponse);
+
+    await timeout(300);
+
+    const doc = await admin
+      .firestore()
+      .collection("revenuecat_events")
+      .doc("uuid")
+      .get();
+    expect(doc.data()).toEqual(validPayload.event);
+  });
+
+  it("doesn't save the event if the REVENUECAT_EVENTS_COLLECTION setting is not set", async () => {
+    jest.resetModules();
+    const originalProcessEnv = process.env;
+    process.env = {
+      ...originalProcessEnv,
+      REVENUECAT_EVENTS_COLLECTION: "",
+    };
+
+    const { handler } = require("../index");
+
+    const mockedResponse = getMockedResponse(expect, () => Promise.resolve())(
+      200,
+      {}
+    ) as any;
+    const mockedRequest = getMockedRequest(
+      createJWT(
+        60,
+        {
+          ...validPayload,
+          event: { ...validPayload.event, id: "not_save_this" },
+        },
+        "test_secret"
+      )
+    ) as any;
+
+    handler(mockedRequest, mockedResponse);
+
+    await timeout(300);
+
+    const doc = await admin
+      .firestore()
+      .collection("revenuecat_events")
+      .doc("not_save_this")
+      .get();
+    expect(doc.data()).toEqual(undefined);
+
+    process.env = originalProcessEnv;
+  });
+
+  it("saves the customer_info in the customer collection", async () => {
+    const mockedResponse = getMockedResponse(expect, () => Promise.resolve())(
+      200,
+      {}
+    ) as any;
+    const mockedRequest = getMockedRequest(
+      createJWT(60, validPayload, "test_secret")
+    ) as any;
+
+    api.handler(mockedRequest, mockedResponse);
+
+    await timeout(500);
+
+    const doc = await admin
+      .firestore()
+      .collection("revenuecat_customers")
+      .doc("chairman_carranza")
+      .get();
+    expect(doc.data()).toEqual({
+      ...validPayload.customer_info,
+      aliases: ["miguelcarranza", "chairman_carranza"],
     });
 
-    it("saves the event in the configured events collection", async () => {
-        const mockedResponse = getMockedResponse(expect, () => Promise.resolve())(200, {}) as any;
-        
-        const mockedRequest = getMockedRequest(createJWT(60, validPayload, "test_secret")) as any;
+    const additionalCustomerInfo = {
+      original_app_user_id: "chairman_carranza",
+      another_field: "baz",
+    };
 
-        api.handler(mockedRequest, mockedResponse);
+    const otherMockedRequest = getMockedRequest(
+      createJWT(
+        60,
+        { ...validPayload, customer_info: additionalCustomerInfo },
+        "test_secret"
+      )
+    ) as any;
 
-        await timeout(300);
+    api.handler(otherMockedRequest, mockedResponse);
 
-        const doc = await admin.firestore().collection("revenuecat_events").doc("uuid").get();
-        expect(doc.data()).toEqual(validPayload.event);
+    await timeout(500);
+
+    const updatedDoc = await admin
+      .firestore()
+      .collection("revenuecat_customers")
+      .doc("chairman_carranza")
+      .get();
+    expect(updatedDoc.data()).toEqual({
+      ...validPayload.customer_info,
+      ...additionalCustomerInfo,
+      aliases: ["miguelcarranza", "chairman_carranza"],
     });
+  });
 
-    it("doesn't save the event if the REVENUECAT_EVENTS_COLLECTION setting is not set", async () => {
-        jest.resetModules();
-        const originalProcessEnv = process.env;
-        process.env = {
-            ...originalProcessEnv,
-            REVENUECAT_EVENTS_COLLECTION: ""
-        }
+  it("doesn't save the event if the REVENUECAT_CUSTOMERS_COLLECTION setting is not set", async () => {
+    jest.resetModules();
+    const originalProcessEnv = process.env;
+    process.env = {
+      ...originalProcessEnv,
+      REVENUECAT_CUSTOMERS_COLLECTION: "",
+    };
 
-        const { handler } = require("../index")
+    const { handler } = require("../index");
 
-        const mockedResponse = getMockedResponse(expect, () => Promise.resolve())(200, {}) as any;
-        const mockedRequest = getMockedRequest(createJWT(60, {...validPayload, event: {...validPayload.event, id: "not_save_this"}}, "test_secret")) as any;
-
-        handler(mockedRequest, mockedResponse);
-
-        await timeout(300);
-
-        const doc = await admin.firestore().collection("revenuecat_events").doc("not_save_this").get();
-        expect(doc.data()).toEqual(undefined);
-
-        process.env = originalProcessEnv;
-    });
-
-    it("saves the customer_info in the customer collection", async () => {
-        const mockedResponse = getMockedResponse(expect, () => Promise.resolve())(200, {}) as any;
-        const mockedRequest = getMockedRequest(createJWT(60, validPayload, "test_secret")) as any;
-
-        api.handler(mockedRequest, mockedResponse);
-
-        await timeout(500);
-
-        const doc = await admin.firestore().collection("revenuecat_customers").doc("chairman_carranza").get();
-        expect(doc.data()).toEqual({...validPayload.customer_info, aliases: ["miguelcarranza", "chairman_carranza"] });
-
-        const additionalCustomerInfo = { original_app_user_id: "chairman_carranza", another_field: "baz" };
-
-        const otherMockedRequest = getMockedRequest(createJWT(60, {...validPayload, customer_info: additionalCustomerInfo }, "test_secret")) as any;
-
-        api.handler(otherMockedRequest, mockedResponse);
-
-        await timeout(500);
-
-        const updatedDoc = await admin.firestore().collection("revenuecat_customers").doc("chairman_carranza").get();
-        expect(updatedDoc.data()).toEqual({...validPayload.customer_info, ...additionalCustomerInfo, aliases: ["miguelcarranza", "chairman_carranza"] });
-    });
-
-    it("doesn't save the event if the REVENUECAT_CUSTOMERS_COLLECTION setting is not set", async () => {
-        jest.resetModules();
-        const originalProcessEnv = process.env;
-        process.env = {
-            ...originalProcessEnv,
-            REVENUECAT_CUSTOMERS_COLLECTION: ""
-        }
-
-        const { handler } = require("../index")
-
-        const mockedResponse = getMockedResponse(expect, () => Promise.resolve())(200, {}) as any;
-        const mockedRequest = getMockedRequest(createJWT(60, { ...validPayload, customer_info: { ...validPayload.customer_info, original_app_user_id: "not_save_this" } }, "test_secret")) as any;
-
-        handler(mockedRequest, mockedResponse);
-
-        await timeout(300);
-
-        const doc = await admin.firestore().collection("revenuecat_customers").doc("not_save_this").get();
-        expect(doc.data()).toEqual(undefined);
-
-        process.env = originalProcessEnv;
-    });
-
-    it("doesn't save the event if the REVENUECAT_CUSTOMERS_COLLECTION setting without a userid", async () => {
-        jest.resetModules();
-        const originalProcessEnv = process.env;
-        process.env = {
-            ...originalProcessEnv,
-            REVENUECAT_CUSTOMERS_COLLECTION: "customers"
-        }
-
-        const { handler } = require("../index")
-
-        const mockedResponse = getMockedResponse(expect, () => Promise.resolve())(200, {}) as any;
-        const mockedRequest = getMockedRequest(createJWT(60, { ...validPayload, app_user_id: null, customer_info: { ...validPayload.customer_info, original_app_user_id: "not_save_this" } }, "test_secret")) as any;
-
-        handler(mockedRequest, mockedResponse);
-
-        await timeout(300);
-
-        const doc = await admin.firestore().collection("revenuecat_customers").doc("not_save_this").get();
-        expect(doc.data()).toEqual(undefined);
-
-        process.env = originalProcessEnv;
-    });
-
-    it("set custom claims for user if SET_CUSTOM_CLAIMS is set", async () => {
-        const testUserId = validPayload.event.app_user_id;
-
-        jest.resetModules();
-        const originalProcessEnv = process.env;
-        process.env = {
-            ...originalProcessEnv,
-            SET_CUSTOM_CLAIMS: "ENABLED"
-        }
-
-        const { handler } = require("../index")
-
-        const auth = admin.auth();
-
-        const userImportRecords = [
-            {
-              uid: testUserId,
-              email: 'user1@example.com',
-              passwordHash: Buffer.from('passwordHash1'),
-              passwordSalt: Buffer.from('salt1'),
-            },
-            {
-              uid: 'leaveThisUserAlone',
-              email: 'user2@example.com',
-              passwordHash: Buffer.from('passwordHash2'),
-              passwordSalt: Buffer.from('salt2'),
-            },
-          ];
-
-        await auth.importUsers(userImportRecords, {
-          hash: {
-            algorithm: 'HMAC_SHA256',
-            key: Buffer.from('secretKey'),
+    const mockedResponse = getMockedResponse(expect, () => Promise.resolve())(
+      200,
+      {}
+    ) as any;
+    const mockedRequest = getMockedRequest(
+      createJWT(
+        60,
+        {
+          ...validPayload,
+          customer_info: {
+            ...validPayload.customer_info,
+            original_app_user_id: "not_save_this",
           },
-        });
+        },
+        "test_secret"
+      )
+    ) as any;
 
-        await timeout(100);
+    handler(mockedRequest, mockedResponse);
 
-        const mockedResponse = getMockedResponse(expect, () => Promise.resolve())(200, {}) as any;
-        const mockedRequest = getMockedRequest(createJWT(60, {...validPayload, customer_info: {...validPayload.customer_info, original_app_user_id: testUserId}}, "test_secret")) as any;
+    await timeout(300);
 
-        handler(mockedRequest, mockedResponse);
+    const doc = await admin
+      .firestore()
+      .collection("revenuecat_customers")
+      .doc("not_save_this")
+      .get();
+    expect(doc.data()).toEqual(undefined);
 
-        await timeout(500);
+    process.env = originalProcessEnv;
+  });
 
-        const { customClaims } = await auth.getUser(testUserId);
+  it("doesn't save the event if the REVENUECAT_CUSTOMERS_COLLECTION setting without a userid", async () => {
+    jest.resetModules();
+    const originalProcessEnv = process.env;
+    process.env = {
+      ...originalProcessEnv,
+      REVENUECAT_CUSTOMERS_COLLECTION: "customers",
+    };
 
-        expect(customClaims).toEqual({revenueCatEntitlements: ["pro", "lifetime"]});
+    const { handler } = require("../index");
 
-        const { customClaims: anotherCustomClaims } = await auth.getUser("leaveThisUserAlone");
-
-        expect(anotherCustomClaims).toEqual(undefined);
-    });
-
-    it("fails gracefully seting custom claims for user if SET_CUSTOM_CLAIMS is set but user doesn't exist", async () => {
-        const testUserId = 'francisco';
-
-        jest.resetModules();
-        const originalProcessEnv = process.env;
-        process.env = {
-            ...originalProcessEnv,
-            SET_CUSTOM_CLAIMS: "ENABLED"
-        }
-
-        const { handler } = require("../index")
-
-        const auth = admin.auth();
-
-        const userImportRecords = [
-            {
-              uid: testUserId,
-              email: 'user1@example.com',
-              passwordHash: Buffer.from('passwordHash1'),
-              passwordSalt: Buffer.from('salt1'),
-            },
-          ];
-
-        await auth.importUsers(userImportRecords, {
-          hash: {
-            algorithm: 'HMAC_SHA256',
-            key: Buffer.from('secretKey'),
+    const mockedResponse = getMockedResponse(expect, () => Promise.resolve())(
+      200,
+      {}
+    ) as any;
+    const mockedRequest = getMockedRequest(
+      createJWT(
+        60,
+        {
+          ...validPayload,
+          app_user_id: null,
+          customer_info: {
+            ...validPayload.customer_info,
+            original_app_user_id: "not_save_this",
           },
-        });
+        },
+        "test_secret"
+      )
+    ) as any;
 
-        await timeout(100);
+    handler(mockedRequest, mockedResponse);
 
-        const mockedResponse = getMockedResponse(expect, (resp) => {
-            expect(resp).toEqual({});            
-        })(200, {}) as any;
+    await timeout(300);
 
-        const mockedRequest = getMockedRequest(createJWT(60, {...validPayload, customer_info: {...validPayload.customer_info, original_app_user_id: "doesntExist"}}, "test_secret")) as any;
+    const doc = await admin
+      .firestore()
+      .collection("revenuecat_customers")
+      .doc("not_save_this")
+      .get();
+    expect(doc.data()).toEqual(undefined);
 
-        await handler(mockedRequest, mockedResponse);
-        await timeout(500);
+    process.env = originalProcessEnv;
+  });
+
+  it("set custom claims for user if SET_CUSTOM_CLAIMS is set", async () => {
+    const testUserId = validPayload.event.app_user_id;
+
+    jest.resetModules();
+    const originalProcessEnv = process.env;
+    process.env = {
+      ...originalProcessEnv,
+      SET_CUSTOM_CLAIMS: "ENABLED",
+    };
+
+    const { handler } = require("../index");
+
+    const auth = admin.auth();
+
+    const userImportRecords = [
+      {
+        uid: testUserId,
+        email: "user1@example.com",
+        passwordHash: Buffer.from("passwordHash1"),
+        passwordSalt: Buffer.from("salt1"),
+      },
+      {
+        uid: "leaveThisUserAlone",
+        email: "user2@example.com",
+        passwordHash: Buffer.from("passwordHash2"),
+        passwordSalt: Buffer.from("salt2"),
+      },
+    ];
+
+    await auth.importUsers(userImportRecords, {
+      hash: {
+        algorithm: "HMAC_SHA256",
+        key: Buffer.from("secretKey"),
+      },
     });
+
+    await timeout(100);
+
+    const mockedResponse = getMockedResponse(expect, () => Promise.resolve())(
+      200,
+      {}
+    ) as any;
+    const mockedRequest = getMockedRequest(
+      createJWT(
+        60,
+        {
+          ...validPayload,
+          customer_info: {
+            ...validPayload.customer_info,
+            original_app_user_id: testUserId,
+          },
+        },
+        "test_secret"
+      )
+    ) as any;
+
+    handler(mockedRequest, mockedResponse);
+
+    await timeout(500);
+
+    const { customClaims } = await auth.getUser(testUserId);
+
+    expect(customClaims).toEqual({
+      revenueCatEntitlements: ["pro", "lifetime"],
+    });
+
+    const { customClaims: anotherCustomClaims } = await auth.getUser(
+      "leaveThisUserAlone"
+    );
+
+    expect(anotherCustomClaims).toEqual(undefined);
+  });
+
+  it("fails gracefully seting custom claims for user if SET_CUSTOM_CLAIMS is set but user doesn't exist", async () => {
+    const testUserId = "francisco";
+
+    jest.resetModules();
+    const originalProcessEnv = process.env;
+    process.env = {
+      ...originalProcessEnv,
+      SET_CUSTOM_CLAIMS: "ENABLED",
+    };
+
+    const { handler } = require("../index");
+
+    const auth = admin.auth();
+
+    const userImportRecords = [
+      {
+        uid: testUserId,
+        email: "user1@example.com",
+        passwordHash: Buffer.from("passwordHash1"),
+        passwordSalt: Buffer.from("salt1"),
+      },
+    ];
+
+    await auth.importUsers(userImportRecords, {
+      hash: {
+        algorithm: "HMAC_SHA256",
+        key: Buffer.from("secretKey"),
+      },
+    });
+
+    await timeout(100);
+
+    const mockedResponse = getMockedResponse(expect, (resp) => {
+      expect(resp).toEqual({});
+    })(200, {}) as any;
+
+    const mockedRequest = getMockedRequest(
+      createJWT(
+        60,
+        {
+          ...validPayload,
+          customer_info: {
+            ...validPayload.customer_info,
+            original_app_user_id: "doesntExist",
+          },
+        },
+        "test_secret"
+      )
+    ) as any;
+
+    await handler(mockedRequest, mockedResponse);
+    await timeout(500);
+  });
 });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -77,20 +77,16 @@ export const handler = functions.https.onRequest(async (request, response) => {
         CUSTOMERS_COLLECTION.replace("{app_user_id}", userId)
       );
 
-      await customersCollection.doc(userId).set(
-        {
-          ...customerPayload,
-          aliases: eventPayload.aliases,
-        },
-        { merge: true }
-      );
+      const payloadToWrite = {
+        ...customerPayload,
+        aliases: eventPayload.aliases,
+      };
 
-      await customersCollection.doc(userId).update(
-        {
-          ...customerPayload,
-          aliases: eventPayload.aliases,
-        },
-      );
+      await customersCollection
+        .doc(userId)
+        .set(payloadToWrite, { merge: true });
+
+      await customersCollection.doc(userId).update(payloadToWrite);
     }
 
     if (SET_CUSTOM_CLAIMS === "ENABLED" && userId) {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -73,7 +73,10 @@ export const handler = functions.https.onRequest(async (request, response) => {
     }
 
     if (CUSTOMERS_COLLECTION && userId) {
-      const customersCollection = firestore.collection(CUSTOMERS_COLLECTION);
+      const customersCollection = firestore.collection(
+        CUSTOMERS_COLLECTION.replace("{app_user_id}", userId)
+      );
+
       await customersCollection.doc(userId).set(
         {
           ...customerPayload,

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -84,6 +84,13 @@ export const handler = functions.https.onRequest(async (request, response) => {
         },
         { merge: true }
       );
+
+      await customersCollection.doc(userId).update(
+        {
+          ...customerPayload,
+          aliases: eventPayload.aliases,
+        },
+      );
     }
 
     if (SET_CUSTOM_CLAIMS === "ENABLED" && userId) {


### PR DESCRIPTION
Fix: https://github.com/RevenueCat/firestore-revenuecat-purchases/issues/34
Fix: https://github.com/RevenueCat/firestore-revenuecat-purchases/issues/33