### PR TITLE
Remove redundant write to document

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -85,8 +85,6 @@ export const handler = functions.https.onRequest(async (request, response) => {
       await customersCollection
         .doc(userId)
         .set(payloadToWrite, { merge: true });
-
-      await customersCollection.doc(userId).update(payloadToWrite);
     }
 
     if (SET_CUSTOM_CLAIMS === "ENABLED" && userId) {


### PR DESCRIPTION
Remove `update(payloadToWrite)` after `set(payloadToWrite, { merge: true })` as this would just overwrite the document directly after creating or merging it with the exact same data. This is probably just an accident. If you want to ensure the document gets either created or replaced, use `set()` without the `merge` flag. If you want to ensure the document gets written, wrap it in a transaction. I just stumbled upon this, thanks for the extension.