### PR TITLE
Fix typo in non_renewing_purchase

### DIFF
--- a/extension.yaml
+++ b/extension.yaml
@@ -140,7 +140,7 @@ events:
     description: Occurs whenever a test event issued through the RevenueCat dashboard.
   - type: com.revenuecat.v1.initial_purchase
     description: Occurs whenever a new subscription has been purchased.
-  - type: com.revenuecat.v1.non_renewing_puchase
+  - type: com.revenuecat.v1.non_renewing_purchase
     description: Occurs whenever a customer has made a purchase that will not auto-renew.
   - type: com.revenuecat.v1.renewal
     description: Occurs whenever an existing subscription has been renewed. This may occur at the end of the current billing period or later if a lapsed user re-subscribes.


### PR DESCRIPTION
Previously there was a typo in the `non_renewing_purchase` event type. This prevented the event handler from publishing `non_renewing_purchase` events to eventarc.