### PR TITLE
Fix automatic version upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.1.7
+
+- Returns extension version as part of the response payload to fix an issue with automatic version ugprades. Fixes https://github.com/RevenueCat/firestore-revenuecat-purchases/issues/48
+
 ## Version 0.1.6
 
 - Fixes a typo in non_renewing_purchase event that prevented publishing to Eventarc. https://github.com/RevenueCat/firestore-revenuecat-purchases/pull/42. Thanks @SDrinkWater!
@@ -10,26 +14,30 @@
 
 - Fixes https://github.com/RevenueCat/firestore-revenuecat-purchases/issues/33
 - Implements subcollections https://github.com/RevenueCat/firestore-revenuecat-purchases/issues/34. Now, the users collection
-parameter can contain a {app_user_id} wildcard to allow for subcollections inside an existing user document.
+  parameter can contain a {app_user_id} wildcard to allow for subcollections inside an existing user document.
 
 ## Version 0.1.3
 
 - Reverts the changes made in 0.1.2 for safety, as that introduced a regression for users that would
-have existing user collections. This is a temporary measure before adding a more robust customer collection configuration.
+  have existing user collections. This is a temporary measure before adding a more robust customer collection configuration.
 
 ## Version 0.1.2
 
 - Attempts to Fix: https://github.com/RevenueCat/firestore-revenuecat-purchases/issues/33 but introduces a regression
-that overwrites existing data.
+  that overwrites existing data.
+
 ## Version 0.1.1
 
 - Updated billing copy in PREINSTALL.md.
+
 ## Version 0.1.0
 
 General audience release.
+
 ## Version 0.0.2
 
 - GitHub repository was renamed to firestore-revenuecat-purchases
+
 ## Version 0.0.1
 
 Initial release of the _Enable In-App Purchases with RevenueCat_ extension.

--- a/extension.yaml
+++ b/extension.yaml
@@ -1,6 +1,6 @@
 name: firestore-revenuecat-purchases
-version: 0.1.6
-specVersion: v1beta  # Firebase Extensions specification version (do not edit)
+version: 0.1.7
+specVersion: v1beta # Firebase Extensions specification version (do not edit)
 
 displayName: Enable In-App Purchases with RevenueCat
 description: Facilitates in-app purchases and subscriptions, controls access to premium content, and syncs purchase information to Firestore.

--- a/functions/src/__tests__/authentication.test.ts
+++ b/functions/src/__tests__/authentication.test.ts
@@ -64,7 +64,8 @@ describe("authentication", () => {
     it("returns a version error if it's not the same", (done) => {
         const expectedError = JSON.stringify({
             code: 2,
-            message: "The version of this extension is not the same. Extension version 0.0.2, Api version: 0.0.1. Please retry the request with the correct version"
+            message: "The version of this extension is not the same. Extension version 0.0.2, Api version: 0.0.1. Please retry the request with the correct version",
+            extension_version: "0.0.2"
         });
 
         const mockedResponse = getMockedResponse(expect, () => done())(400, expectedError) as any;

--- a/functions/src/__tests__/utils.ts
+++ b/functions/src/__tests__/utils.ts
@@ -3,7 +3,8 @@ import nJwt, { JSONMap } from "njwt";
 // TODO: add docs
 export const EXPECTED_AUTH_ERROR = JSON.stringify({
     code:1,
-    message: "Incoming RevenueCat webhook could not be authenticated. Please check that the shared secret is set up correctly."
+    message: "Incoming RevenueCat webhook could not be authenticated. Please check that the shared secret is set up correctly.",
+    extension_version: "0.0.2"
 });
 
 export const createJWT = (expirationSeconds: number, payload: JSONMap, secretKey: string) => {
@@ -21,7 +22,7 @@ export const createJWT = (expirationSeconds: number, payload: JSONMap, secretKey
 type OnSend = (payload: Object) => void;
 type MockedResponseCallable = (expectedStatusCode: number, expectedResponse: Object) => any;
 
-export function getMockedResponse(expect: any, onSend: OnSend): MockedResponseCallable { 
+export function getMockedResponse(expect: any, onSend: OnSend): MockedResponseCallable {
     return (expectedStatusCode, expectedResponse) => ({
         header: function(headerKey: string, headerValue: string) {
             if (!this.headers) {
@@ -33,7 +34,7 @@ export function getMockedResponse(expect: any, onSend: OnSend): MockedResponseCa
         getHeaders: function() {
             return this.headers;
         },
-        status: function (code: number) { 
+        status: function (code: number) {
             expect(code).toBe(expectedStatusCode);
             // @ts-ignore
             this.statusCode = code;

--- a/functions/src/error-handler.ts
+++ b/functions/src/error-handler.ts
@@ -4,12 +4,14 @@ import { logger, Response } from "firebase-functions";
 interface ErrorPayload {
     code: number,
     message: string
+    extension_version?: string
 }
 
-const constructResponsePayload = (exception: ExtensionError): ErrorPayload => {
+const constructResponsePayload = (exception: ExtensionError, extensionVersion?: string): ErrorPayload => {
     return {
         code: exception.code(),
-        message: exception.message
+        message: exception.message,
+        extension_version: extensionVersion,
     }
 }
 
@@ -19,7 +21,7 @@ const sendErrorResponse = async (httpStatus: number, response: Response, payload
     ));
 }
 
-export const requestErrorHandler = (exception: Error, response: Response) => {
+export const requestErrorHandler = (exception: Error, response: Response, extensionVersion?: string) => {
     let responsePayload;
     let extensionException: ExtensionError;
 
@@ -31,7 +33,7 @@ export const requestErrorHandler = (exception: Error, response: Response) => {
         extensionException = new UnknownError();
     }
 
-    responsePayload = constructResponsePayload(extensionException)
+    responsePayload = constructResponsePayload(extensionException, extensionVersion)
 
     return sendErrorResponse(extensionException.httpStatusCode(), response, responsePayload);
 };

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -28,7 +28,7 @@ const CUSTOMERS_COLLECTION = process.env.REVENUECAT_CUSTOMERS_COLLECTION as
 const SET_CUSTOM_CLAIMS = process.env.SET_CUSTOM_CLAIMS as
   | "ENABLED"
   | "DISABLED";
-const EXTENSION_VERSION = process.env.EXTENSION_VERSION || "0.1.6";
+const EXTENSION_VERSION = process.env.EXTENSION_VERSION || "0.1.7";
 
 const getCustomersCollection = ({
   firestore,
@@ -177,6 +177,6 @@ export const handler = functions.https.onRequest(async (request, response) => {
 
     response.send({});
   } catch (err) {
-    requestErrorHandler(err as Error, response);
+    requestErrorHandler(err as Error, response, EXTENSION_VERSION);
   }
 });


### PR DESCRIPTION
Fixes: https://github.com/RevenueCat/firestore-revenuecat-purchases/issues/48

Firebase will sometimes not return custom headers to our backend. This results in `X-Extension-Version` not being able to be consumed and make the automatic version upgrading system not work.

This change returns the version in the body of the response as well.