### PR TITLE
chore: Upgrade Node.js from version 14 to version 18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.1.12
+
+- Upgraded Node.js from version 14 to version 18 https://github.com/RevenueCat/firestore-revenuecat-purchases/pull/66/files
+
 ## Version 0.1.11
 
 - Upgraded protobufjs to address a security vulnerability https://github.com/RevenueCat/firestore-revenuecat-purchases/pull/62/files

--- a/extension.yaml
+++ b/extension.yaml
@@ -1,5 +1,5 @@
 name: firestore-revenuecat-purchases
-version: 0.1.11
+version: 0.1.12
 specVersion: v1beta # Firebase Extensions specification version (do not edit)
 
 displayName: Enable In-App Purchases with RevenueCat

--- a/extension.yaml
+++ b/extension.yaml
@@ -30,7 +30,7 @@ resources:
       Listens for RevenueCat server webhook requests, and store customer information and events in Cloud Firestore.
     properties:
       location: ${LOCATION}
-      runtime: nodejs14
+      runtime: nodejs18
       httpsTrigger: {}
 
 params:

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -141,9 +141,7 @@
           "dev": true
         },
         "json5": {
-          "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-          "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+          "version": "^2.2.3",
           "dev": true
         },
         "ms": {
@@ -7429,9 +7427,7 @@
       },
       "dependencies": {
         "json5": {
-          "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-          "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+          "version": "^2.2.3",
           "dev": true
         },
         "semver": {
@@ -7487,15 +7483,13 @@
       "dev": true,
       "requires": {
         "@types/json5": "^0.0.29",
-        "json5": "^1.0.1",
+        "json5": "^2.2.3",
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
       },
       "dependencies": {
         "json5": {
-          "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-          "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+          "version": "^2.2.3",
           "dev": true
         }
       }

--- a/functions/package.json
+++ b/functions/package.json
@@ -15,7 +15,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "16"
+    "node": "18"
   },
   "main": "lib/index.js",
   "dependencies": {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -28,7 +28,7 @@ const CUSTOMERS_COLLECTION = process.env.REVENUECAT_CUSTOMERS_COLLECTION as
 const SET_CUSTOM_CLAIMS = process.env.SET_CUSTOM_CLAIMS as
   | "ENABLED"
   | "DISABLED";
-const EXTENSION_VERSION = process.env.EXTENSION_VERSION || "0.1.11";
+const EXTENSION_VERSION = process.env.EXTENSION_VERSION || "0.1.12";
 
 const getCustomersCollection = ({
   firestore,


### PR DESCRIPTION
Node.js 14 will be deprecated by Google Cloud on Jan 30, 2024.

This PR upgrades Node.js from version 14 to version 18