### PR TITLE
feat: migrate date fields from string to Firestore Timestamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ node_modules/
 
 # macOS system file
 .DS_store
+
+# IDE personal folder
+.idea

--- a/POSTINSTALL.md
+++ b/POSTINSTALL.md
@@ -67,7 +67,7 @@ getDoc(doc(db, "${param:REVENUECAT_CUSTOMERS_COLLECTION}", getAuth().currentUser
   .then((snapshot) => {
     if (snapshot.exists()) {
       snapshot.subscriptions
-        .filter(subscription => new Date(subscription.expires_date) >= new Date())
+        .filter(subscription => subscription.expires_date.toDate() >= new Date())
         .forEach(subscription => console.log(JSON.stringify(subscription)));
     }
   });

--- a/functions/src/types.ts
+++ b/functions/src/types.ts
@@ -1,3 +1,5 @@
+import {firestore} from "firebase-admin";
+
 type EventType =
   | "INITIAL_PURCHASE"
   | "RENEWAL"
@@ -12,10 +14,10 @@ type EventType =
   | "EXPIRATION";
 
 interface Entitlement {
-  expires_date: string;
-  purchase_date: string;
+  expires_date: firestore.Timestamp;
+  purchase_date: firestore.Timestamp;
   product_identifier: string;
-  grace_period_expires_date: string;
+  grace_period_expires_date: firestore.Timestamp;
 }
 
 export interface CustomerInfo {


### PR DESCRIPTION
This PR aim to help fixing the following issue : https://github.com/RevenueCat/firestore-revenuecat-purchases/issues/86

I didn't what is the best practice to handle data migration from old extension using STRING to this new version using TIMESTAMP.