### PR TITLE
Updating multiple libs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Version 0.1.17
+
+- Upgrade to multiple libraries
+- Upgrading firebase-admin to the latest version to fix permissions error in the function when setting custom claims.
+
 ## Version 0.1.16
 
 - Upgraded Node.js from version 18 to version 20 https://github.com/RevenueCat/firestore-revenuecat-purchases/pull/98/files

--- a/extension.yaml
+++ b/extension.yaml
@@ -1,5 +1,5 @@
 name: firestore-revenuecat-purchases
-version: 0.1.16
+version: 0.1.17
 specVersion: v1beta # Firebase Extensions specification version (do not edit)
 
 displayName: Enable In-App Purchases with RevenueCat

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -9,14 +9,14 @@
       "dependencies": {
         "express": "^4.21.1",
         "fast-deep-equal": "^3.1.3",
-        "firebase-admin": "^12.3.0",
-        "firebase-functions": "^5.0.1",
+        "firebase-admin": "^13.2.0",
+        "firebase-functions": "^6.3.2",
         "moment": "^2.29.1",
         "njwt": "^2.0.1",
         "typescript": "^4.9.5"
       },
       "devDependencies": {
-        "@firebase/rules-unit-testing": "^3.0.4",
+        "@firebase/rules-unit-testing": "^4.0.1",
         "@types/jest": "^27.4.1",
         "@typescript-eslint/eslint-plugin": "^3.9.1",
         "@typescript-eslint/parser": "^3.8.0",
@@ -24,7 +24,7 @@
         "eslint": "^7.6.0",
         "eslint-config-google": "^0.14.0",
         "eslint-plugin-import": "^2.22.0",
-        "firebase-functions-test": "^3.3.0",
+        "firebase-functions-test": "^3.4.1",
         "jest": "^29.7.0",
         "ts-jest": "^29.1.1",
         "ts-node": "^10.9.1"
@@ -123,18 +123,21 @@
       "license": "MIT"
     },
     "node_modules/@firebase/app-compat": {
-      "version": "0.2.43",
-      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.2.43.tgz",
-      "integrity": "sha512-HM96ZyIblXjAC7TzE8wIk2QhHlSvksYkQ4Ukh1GmEenzkucSNUmUX4QvoKrqeWsLEQ8hdcojABeCV8ybVyZmeg==",
+      "version": "0.2.51",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.2.51.tgz",
+      "integrity": "sha512-pxF1+coABt+ugqNI0YXDlmkKv4kh3pjI5BqIJJ1VXBo42OZbKMsQbFeos14YBrWwiqqSjUvQ70FBNsv5E2wuxg==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@firebase/app": "0.10.13",
-        "@firebase/component": "0.6.9",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.10.0",
+        "@firebase/app": "0.11.2",
+        "@firebase/component": "0.6.13",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.11.0",
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@protobufjs/path": {
@@ -147,7 +150,6 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/stream-shift": {
@@ -235,7 +237,6 @@
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
       "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -427,18 +428,18 @@
       }
     },
     "node_modules/@firebase/performance-compat": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.9.tgz",
-      "integrity": "sha512-dNl95IUnpsu3fAfYBZDCVhXNkASE0uo4HYaEPd2/PKscfTvsgqFAOxfAXzBEDOnynDWiaGUnb5M1O00JQ+3FXA==",
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.14.tgz",
+      "integrity": "sha512-/crPg0fDqHIx+FjFoEqWxNp+lJSF40ZG7x43AAJGRaUaWLJDncQm3UJB5/mABaRZb7obs1CQAcRtd4phZFkmZg==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@firebase/component": "0.6.9",
-        "@firebase/logger": "0.4.2",
-        "@firebase/performance": "0.6.9",
-        "@firebase/performance-types": "0.2.2",
-        "@firebase/util": "1.10.0",
+        "@firebase/component": "0.6.13",
+        "@firebase/logger": "0.4.4",
+        "@firebase/performance": "0.7.1",
+        "@firebase/performance-types": "0.2.3",
+        "@firebase/util": "1.11.0",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -646,9 +647,9 @@
       }
     },
     "node_modules/@firebase/performance-types": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.2.tgz",
-      "integrity": "sha512-gVq0/lAClVH5STrIdKnHnCo2UcPLjJlDUoEB/tB4KM+hAeHUxWKnpT0nemUPvxZ5nbdY/pybeyMe8Cs29gEcHA==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.3.tgz",
+      "integrity": "sha512-IgkyTz6QZVPAq8GSkLYJvwSLr3LS9+V6vNPQr0x4YozZJiLF5jYixj0amDtATf1X0EtYHqoPO48a9ija8GocxQ==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true
@@ -805,27 +806,28 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/firebase-admin": {
-      "version": "12.7.0",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-12.7.0.tgz",
-      "integrity": "sha512-raFIrOyTqREbyXsNkSHyciQLfv8AUZazehPaQS1lZBSCDYW74FYXU0nQZa3qHI4K+hawohlDbywZ4+qce9YNxA==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.2.0.tgz",
+      "integrity": "sha512-qQBTKo0QWCDaWwISry989pr8YfZSSk00rNCKaucjOgltEm3cCYzEe4rODqBd1uUwma+Iu5jtAzg89Nfsjr3fGg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/busboy": "^3.0.0",
-        "@firebase/database-compat": "1.0.8",
-        "@firebase/database-types": "1.0.5",
-        "@types/node": "^22.0.1",
+        "@firebase/database-compat": "^2.0.0",
+        "@firebase/database-types": "^1.0.6",
+        "@types/node": "^22.8.7",
         "farmhash-modern": "^1.1.0",
+        "google-auth-library": "^9.14.2",
         "jsonwebtoken": "^9.0.0",
         "jwks-rsa": "^3.1.0",
         "node-forge": "^1.3.1",
-        "uuid": "^10.0.0"
+        "uuid": "^11.0.2"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "optionalDependencies": {
-        "@google-cloud/firestore": "^7.7.0",
-        "@google-cloud/storage": "^7.7.0"
+        "@google-cloud/firestore": "^7.11.0",
+        "@google-cloud/storage": "^7.14.0"
       }
     },
     "node_modules/lru-memoizer/node_modules/yallist": {
@@ -961,9 +963,9 @@
       }
     },
     "node_modules/@firebase/functions-types": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.2.tgz",
-      "integrity": "sha512-0KiJ9lZ28nS2iJJvimpY4nNccV21rkQyor5Iheu/nq8aKXJqtJdeSlZDspjPSBBiHRzo7/GMUttegnsEITqR+w==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.3.tgz",
+      "integrity": "sha512-EZoDKQLUHFKNx6VLipQwrSMh01A1SaL3Wg6Hpi//x6/fJ6Ee4hrAeswK99I5Ht8roiniKHw4iO0B1Oxj5I4plg==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true
@@ -1143,27 +1145,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/teeny-request/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
       }
     },
     "node_modules/caniuse-lite": {
@@ -1398,7 +1379,6 @@
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
       "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
@@ -1530,7 +1510,6 @@
       "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
       "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=14"
       }
@@ -1662,12 +1641,16 @@
       }
     },
     "node_modules/@firebase/util": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.10.0.tgz",
-      "integrity": "sha512-xKtx4A668icQqoANRxyDLBLz51TAbDP9KRfpbKGxiCAW346d0BeJe5vN6/hKxxmWwnZ0mautyv39JxviwwQMOQ==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.11.0.tgz",
+      "integrity": "sha512-PzSrhIr++KI6y4P6C/IdgBNMkEx0Ex6554/cYd0Hm+ovyFSJtJXqb/3OSIdnBoa2cpwZT1/GW56EmRc5qEc5fQ==",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@protobufjs/pool": {
@@ -1706,24 +1689,23 @@
       }
     },
     "node_modules/@firebase/firestore": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.7.3.tgz",
-      "integrity": "sha512-NwVU+JPZ/3bhvNSJMCSzfcBZZg8SUGyzZ2T0EW3/bkUeefCyzMISSt/TTIfEHc8cdyXGlMqfGe3/62u9s74UEg==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.7.9.tgz",
+      "integrity": "sha512-uq/bUtHDqJ5ZqPHAJIlNzHpXUtcVYcASz2V6y7UmP1WLlRKEt1yf1OcQW5u8pY2yq7162OnCl5J5mkOdMTMLZw==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@firebase/component": "0.6.9",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.10.0",
-        "@firebase/webchannel-wrapper": "1.0.1",
+        "@firebase/component": "0.6.13",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.11.0",
+        "@firebase/webchannel-wrapper": "1.0.3",
         "@grpc/grpc-js": "~1.9.0",
         "@grpc/proto-loader": "^0.7.8",
-        "tslib": "^2.1.0",
-        "undici": "6.19.7"
+        "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=10.10.0"
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "@firebase/app": "0.x"
@@ -1761,9 +1743,9 @@
       }
     },
     "node_modules/@firebase/app-check-types": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.2.tgz",
-      "integrity": "sha512-FSOEzTzL5bLUbD2co3Zut46iyPWML6xc4x+78TeaXMSuJap5QObfb+rVvZJtla3asN4RwU7elaQaduP+HFizDA==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.3.tgz",
+      "integrity": "sha512-hyl5rKSj0QmwPdsAxrI5x1otDlByQ7bvNvVt8G/XPO2CSwE++rmSVf3VEhaeOR4J8ZFaF0Z0NDSmLejPweZ3ng==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true
@@ -1787,10 +1769,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dev": true,
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -1930,7 +1911,6 @@
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
-      "optional": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -2245,9 +2225,9 @@
       }
     },
     "node_modules/@firebase/messaging-interop-types": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.2.tgz",
-      "integrity": "sha512-l68HXbuD2PPzDUOFb3aG+nZj5KA3INcPwlocwLZOzPp9rFM9yeuI9YLl6DQfguTX5eAGxO0doTR+rDLDvQb5tA==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.3.tgz",
+      "integrity": "sha512-xfzFaJpzcmtDjycpDeCUj0Ge10ATFi/VHVIvEEjDNc3hodVBQADZ7BWQU7CuFpjSHE+eLuBI13z5F/9xOoGX8Q==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true
@@ -2537,36 +2517,42 @@
       }
     },
     "node_modules/@firebase/app-check": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.8.8.tgz",
-      "integrity": "sha512-O49RGF1xj7k6BuhxGpHmqOW5hqBIAEbt2q6POW0lIywx7emYtzPDeQI+ryQpC4zbKX646SoVZ711TN1DBLNSOQ==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.8.12.tgz",
+      "integrity": "sha512-LxjcoIFOU4sgK07ZWb8XDHxuVB+UKs41vPK+Sg9PeZMvEoz84fndFAx8Nz2nipiya2EmyxBgVhff8Hi6GBt+XA==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@firebase/component": "0.6.9",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.10.0",
+        "@firebase/component": "0.6.13",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.11.0",
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "@firebase/app": "0.x"
       }
     },
     "node_modules/@firebase/app-check-compat": {
-      "version": "0.3.15",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.3.15.tgz",
-      "integrity": "sha512-zFIvIFFNqDXpOT2huorz9cwf56VT3oJYRFjSFYdSbGYEJYEaXjLJbfC79lx/zjx4Fh+yuN8pry3TtvwaevrGbg==",
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.3.19.tgz",
+      "integrity": "sha512-G8FMiqhrKc4gEEujrBDBBrbRav8MGqoLObWj1hy/riCSg4XlRYhpnq3ev8E9HTirqU1tAGH6oJl7vr+jfM7YNA==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@firebase/app-check": "0.8.8",
-        "@firebase/app-check-types": "0.5.2",
-        "@firebase/component": "0.6.9",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.10.0",
+        "@firebase/app-check": "0.8.12",
+        "@firebase/app-check-types": "0.5.3",
+        "@firebase/component": "0.6.13",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.11.0",
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "@firebase/app-compat": "0.x"
@@ -2647,40 +2633,25 @@
       }
     },
     "node_modules/@firebase/functions": {
-      "version": "0.11.8",
-      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.11.8.tgz",
-      "integrity": "sha512-Lo2rTPDn96naFIlSZKVd1yvRRqqqwiJk7cf9TZhUerwnPKgBzXy+aHE22ry+6EjCaQusUoNai6mU6p+G8QZT1g==",
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.12.3.tgz",
+      "integrity": "sha512-Wv7JZMUkKLb1goOWRtsu3t7m97uK6XQvjQLPvn8rncY91+VgdU72crqnaYCDI/ophNuBEmuK8mn0/pAnjUeA6A==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@firebase/app-check-interop-types": "0.3.2",
-        "@firebase/auth-interop-types": "0.2.3",
-        "@firebase/component": "0.6.9",
-        "@firebase/messaging-interop-types": "0.2.2",
-        "@firebase/util": "1.10.0",
-        "tslib": "^2.1.0",
-        "undici": "6.19.7"
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.6.13",
+        "@firebase/messaging-interop-types": "0.2.3",
+        "@firebase/util": "1.11.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "@firebase/app": "0.x"
-      }
-    },
-    "node_modules/@types/request/node_modules/form-data": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.3.tgz",
-      "integrity": "sha512-XHIrMD0NpDrNM/Ckf7XJiBbLl57KEhT3+i3yY+eWm+cqYZJQTZrKo8Y8AWKnuV5GT4scfuUGt9LzNoIx3dU1nQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "mime-types": "^2.1.35",
-        "safe-buffer": "^5.2.1"
-      },
-      "engines": {
-        "node": ">= 0.12"
       }
     },
     "node_modules/jest-validate": {
@@ -2736,16 +2707,16 @@
       "license": "MIT"
     },
     "node_modules/@firebase/messaging-compat": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.12.tgz",
-      "integrity": "sha512-pKsiUVZrbmRgdImYqhBNZlkKJbqjlPkVdQRZGRbkTyX4OSGKR0F/oJeCt1a8jEg5UnBp4fdVwSWSp4DuCovvEQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.17.tgz",
+      "integrity": "sha512-5Q+9IG7FuedusdWHVQRjpA3OVD9KUWp/IPegcv0s5qSqRLBjib7FlAeWxN+VL0Ew43tuPJBY2HKhEecuizmO1Q==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@firebase/component": "0.6.9",
-        "@firebase/messaging": "0.12.12",
-        "@firebase/util": "1.10.0",
+        "@firebase/component": "0.6.13",
+        "@firebase/messaging": "0.12.17",
+        "@firebase/util": "1.11.0",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -2872,9 +2843,9 @@
       "license": "MIT"
     },
     "node_modules/@firebase/auth-interop-types": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.3.tgz",
-      "integrity": "sha512-Fc9wuJGgxoxQeavybiuwgyi+0rssr76b+nHpj+eGhXFYAdudMWyfBHvFL/I5fEHniUM/UQdFzi9VXJK2iZF7FQ==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.4.tgz",
+      "integrity": "sha512-JPgcXKCuO+CWqGDnigBtvo09HeBs5u/Ktc2GaFj2m01hLarbxthLNm7Fk8iOP1aqAtXV+fnnGj7U28xmk7IwVA==",
       "license": "Apache-2.0"
     },
     "node_modules/@protobufjs/codegen": {
@@ -2902,7 +2873,6 @@
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
       "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": "*"
       }
@@ -2988,17 +2958,17 @@
       }
     },
     "node_modules/@firebase/analytics-compat": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.14.tgz",
-      "integrity": "sha512-unRVY6SvRqfNFIAA/kwl4vK+lvQAL2HVcgu9zTrUtTyYDmtIt/lOuHJynBMYEgLnKm39YKBDhtqdapP2e++ASw==",
+      "version": "0.2.18",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.18.tgz",
+      "integrity": "sha512-Hw9mzsSMZaQu6wrTbi3kYYwGw9nBqOHr47pVLxfr5v8CalsdrG5gfs9XUlPOZjHRVISp3oQrh1j7d3E+ulHPjQ==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@firebase/analytics": "0.10.8",
-        "@firebase/analytics-types": "0.8.2",
-        "@firebase/component": "0.6.9",
-        "@firebase/util": "1.10.0",
+        "@firebase/analytics": "0.10.12",
+        "@firebase/analytics-types": "0.8.3",
+        "@firebase/component": "0.6.13",
+        "@firebase/util": "1.11.0",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -3171,7 +3141,6 @@
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
       "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "bignumber.js": "^9.0.0"
       }
@@ -3190,18 +3159,21 @@
       }
     },
     "node_modules/@firebase/firestore-compat": {
-      "version": "0.3.38",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.3.38.tgz",
-      "integrity": "sha512-GoS0bIMMkjpLni6StSwRJarpu2+S5m346Na7gr9YZ/BZ/W3/8iHGNr9PxC+f0rNZXqS4fGRn88pICjrZEgbkqQ==",
+      "version": "0.3.44",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.3.44.tgz",
+      "integrity": "sha512-4Lv2TyHEW+FugXPgmQ0ZylSbh9uFuKDP0lCL1hX9cbxXaafhC/Nww+DWokUQ2zZcynjc8fxFunw6Xbd3QHAlgA==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@firebase/component": "0.6.9",
-        "@firebase/firestore": "4.7.3",
-        "@firebase/firestore-types": "3.0.2",
-        "@firebase/util": "1.10.0",
+        "@firebase/component": "0.6.13",
+        "@firebase/firestore": "4.7.9",
+        "@firebase/firestore-types": "3.0.3",
+        "@firebase/util": "1.11.0",
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "@firebase/app-compat": "0.x"
@@ -3265,19 +3237,21 @@
       }
     },
     "node_modules/@firebase/auth-compat": {
-      "version": "0.5.14",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.5.14.tgz",
-      "integrity": "sha512-2eczCSqBl1KUPJacZlFpQayvpilg3dxXLy9cSMTKtQMTQSmondUtPI47P3ikH3bQAXhzKLOE+qVxJ3/IRtu9pw==",
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.5.19.tgz",
+      "integrity": "sha512-v898POphOIBJliKF76SiGOXh4EdhO5fM6S9a2ZKf/8wHdBea/qwxwZoVVya4DW6Mi7vWyp1lIzHbFgwRz8G9TA==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@firebase/auth": "1.7.9",
-        "@firebase/auth-types": "0.12.2",
-        "@firebase/component": "0.6.9",
-        "@firebase/util": "1.10.0",
-        "tslib": "^2.1.0",
-        "undici": "6.19.7"
+        "@firebase/auth": "1.9.1",
+        "@firebase/auth-types": "0.13.0",
+        "@firebase/component": "0.6.13",
+        "@firebase/util": "1.11.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "@firebase/app-compat": "0.x"
@@ -3392,27 +3366,6 @@
         "ms": "2.0.0"
       }
     },
-    "node_modules/google-gax/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@jest/environment": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
@@ -3512,7 +3465,6 @@
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
       "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "gaxios": "^6.1.1",
         "google-logging-utils": "^0.0.2",
@@ -3622,13 +3574,14 @@
       }
     },
     "node_modules/@types/express": {
-      "version": "4.17.3",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.3.tgz",
-      "integrity": "sha512-I8cGRJj3pyOLs/HndoP+25vOqhqWkAZsWMEmq1qXy/b/M3ppufecUwaK2/TVDVxcV61/iSdhykUjQQ2DLSrTdg==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
         "@types/serve-static": "*"
       }
     },
@@ -3861,20 +3814,16 @@
       }
     },
     "node_modules/@firebase/rules-unit-testing": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@firebase/rules-unit-testing/-/rules-unit-testing-3.0.4.tgz",
-      "integrity": "sha512-FxDc5rnTtt266PTs3dOkf4ZDq+P223TrFWXka/yG6gSFy3Es/iKwWh3bX9pROobHgbbrAd7she9+687yOC2z+A==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@firebase/rules-unit-testing/-/rules-unit-testing-4.0.1.tgz",
+      "integrity": "sha512-Vu8iMLP+dO9hCAqUCitWZQdORyM6CxucilRZtleeTZd5bejZmyOiaBPwYm3NOYG6025ac99CEeA+ETmJRxa9zg==",
       "dev": true,
       "license": "Apache-2.0",
-      "dependencies": {
-        "@types/node-fetch": "2.6.4",
-        "node-fetch": "2.6.7"
-      },
       "engines": {
-        "node": ">=10.10.0"
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "firebase": "^10.0.0"
+        "firebase": "^11.0.0"
       }
     },
     "node_modules/word-wrap": {
@@ -3888,16 +3837,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/p-limit": {
@@ -4120,8 +4069,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -4157,8 +4105,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__generator": {
       "version": "7.6.8",
@@ -4171,9 +4118,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.6.tgz",
-      "integrity": "sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==",
+      "version": "4.19.6",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
+      "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -4380,18 +4327,21 @@
       }
     },
     "node_modules/@firebase/app": {
-      "version": "0.10.13",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.10.13.tgz",
-      "integrity": "sha512-OZiDAEK/lDB6xy/XzYAyJJkaDqmQ+BCtOEPLqFvxWKUz5JbBmej7IiiRHdtiIOD/twW7O5AxVsfaaGA/V1bNsA==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.11.2.tgz",
+      "integrity": "sha512-bFee0hPJZBzNtiizRxdgsu8C9DW3mn1y0OJJ4zHQsccjDYzGOfvN0G3CMGyBIiwNctsFpQa8orbp2IKywoUeqA==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@firebase/component": "0.6.9",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.10.0",
+        "@firebase/component": "0.6.13",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.11.0",
         "idb": "7.1.1",
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@protobufjs/eventemitter": {
@@ -5045,18 +4995,21 @@
       }
     },
     "node_modules/@firebase/logger": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.2.tgz",
-      "integrity": "sha512-Q1VuA5M1Gjqrwom6I6NUU4lQXdo9IAQieXlujeHZWvRt1b7qQ0KwBaNAjgxG27jgF9/mUwsNmO8ptBCGVYhB0A==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.4.tgz",
+      "integrity": "sha512-mH0PEh1zoXGnaR8gD1DeGeNZtWFKbnz9hDO91dIml3iou1gpOnLqXQ2dJfB71dj6dpmUjcQ6phY3ZZJbjErr9g==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@firebase/storage-types": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.2.tgz",
-      "integrity": "sha512-0vWu99rdey0g53lA7IShoA2Lol1jfnPovzLDUBuon65K7uKG9G+L5uO05brD9pMw+l4HRFw23ah3GwTGpEav6g==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.3.tgz",
+      "integrity": "sha512-+Muk7g9uwngTpd8xn9OdF/D48uiQ7I1Fae7ULsWPuKoCH3HU7bfFPhxtJYzyhjdniowhuDpQcfPmuNRAqZEfvg==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -5191,7 +5144,6 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -5715,18 +5667,18 @@
       }
     },
     "node_modules/@firebase/remote-config-compat": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.9.tgz",
-      "integrity": "sha512-AxzGpWfWFYejH2twxfdOJt5Cfh/ATHONegTd/a0p5flEzsD5JsxXgfkFToop+mypEL3gNwawxrxlZddmDoNxyA==",
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.13.tgz",
+      "integrity": "sha512-UmHoO7TxAEJPIZf8e1Hy6CeFGMeyjqSCpgoBkQZYXFI2JHhzxIyDpr8jVKJJN1dmAePKZ5EX7dC13CmcdTOl7Q==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@firebase/component": "0.6.9",
-        "@firebase/logger": "0.4.2",
-        "@firebase/remote-config": "0.4.9",
-        "@firebase/remote-config-types": "0.3.2",
-        "@firebase/util": "1.10.0",
+        "@firebase/component": "0.6.13",
+        "@firebase/logger": "0.4.4",
+        "@firebase/remote-config": "0.6.0",
+        "@firebase/remote-config-types": "0.4.0",
+        "@firebase/util": "1.11.0",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -5747,18 +5699,19 @@
       }
     },
     "node_modules/@firebase/performance": {
-      "version": "0.6.9",
-      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.6.9.tgz",
-      "integrity": "sha512-PnVaak5sqfz5ivhua+HserxTJHtCar/7zM0flCX6NkzBNzJzyzlH4Hs94h2Il0LQB99roBqoE5QT1JqWqcLJHQ==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.1.tgz",
+      "integrity": "sha512-SkEUurawojCjav2V2AXo6BQLDtv02NxgXPLCiAvrkn95IAKI4W/UbLKYQvMbEez/nqvmnucLyklcMlB0Q5a1iw==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@firebase/component": "0.6.9",
-        "@firebase/installations": "0.6.9",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.10.0",
-        "tslib": "^2.1.0"
+        "@firebase/component": "0.6.13",
+        "@firebase/installations": "0.6.13",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.11.0",
+        "tslib": "^2.1.0",
+        "web-vitals": "^4.2.4"
       },
       "peerDependencies": {
         "@firebase/app": "0.x"
@@ -5971,17 +5924,17 @@
       }
     },
     "node_modules/@firebase/data-connect": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.1.0.tgz",
-      "integrity": "sha512-vSe5s8dY13ilhLnfY0eYRmQsdTbH7PUFZtBbqU6JVX/j8Qp9A6G5gG6//ulbX9/1JFOF1IWNOne9c8S/DOCJaQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.3.1.tgz",
+      "integrity": "sha512-PNlfAJ2mcbyRlWfm41nfk8EksTuvMFTFIX+puNzeUa6OTIDtyp1IX1NJVc7n6WpfbErN7tNqcOEMe6BMtpcjVA==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@firebase/auth-interop-types": "0.2.3",
-        "@firebase/component": "0.6.9",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.10.0",
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.6.13",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.11.0",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -6089,8 +6042,8 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
@@ -6188,18 +6141,21 @@
       }
     },
     "node_modules/@firebase/storage-compat": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.3.12.tgz",
-      "integrity": "sha512-hA4VWKyGU5bWOll+uwzzhEMMYGu9PlKQc1w4DWxB3aIErWYzonrZjF0icqNQZbwKNIdh8SHjZlFeB2w6OSsjfg==",
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.3.17.tgz",
+      "integrity": "sha512-CBlODWEZ5b6MJWVh21VZioxwxNwVfPA9CAdsk+ZgVocJQQbE2oDW1XJoRcgthRY1HOitgbn4cVrM+NlQtuUYhw==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@firebase/component": "0.6.9",
-        "@firebase/storage": "0.13.2",
-        "@firebase/storage-types": "0.8.2",
-        "@firebase/util": "1.10.0",
+        "@firebase/component": "0.6.13",
+        "@firebase/storage": "0.13.7",
+        "@firebase/storage-types": "0.8.3",
+        "@firebase/util": "1.11.0",
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "@firebase/app-compat": "0.x"
@@ -6372,41 +6328,41 @@
       }
     },
     "node_modules/firebase": {
-      "version": "10.14.1",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-10.14.1.tgz",
-      "integrity": "sha512-0KZxU+Ela9rUCULqFsUUOYYkjh7OM1EWdIfG6///MtXd0t2/uUIf0iNV5i0KariMhRQ5jve/OY985nrAXFaZeQ==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-11.4.0.tgz",
+      "integrity": "sha512-Z6kwhWIPDgIm0+NUEQxwjH14hMP7t42WSFnf/78R0Vh59VovLYTOCTM3MIdY3jlSZ9uKz56FhXrvsNXNhAn/Xg==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@firebase/analytics": "0.10.8",
-        "@firebase/messaging": "0.12.12",
-        "@firebase/analytics-compat": "0.2.14",
-        "@firebase/auth": "1.7.9",
-        "@firebase/firestore": "4.7.3",
-        "@firebase/vertexai-preview": "0.0.4",
-        "@firebase/installations": "0.6.9",
-        "@firebase/app": "0.10.13",
-        "@firebase/app-check": "0.8.8",
-        "@firebase/data-connect": "0.1.0",
-        "@firebase/functions-compat": "0.3.14",
-        "@firebase/auth-compat": "0.5.14",
-        "@firebase/performance-compat": "0.2.9",
-        "@firebase/storage": "0.13.2",
-        "@firebase/firestore-compat": "0.3.38",
-        "@firebase/util": "1.10.0",
-        "@firebase/storage-compat": "0.3.12",
-        "@firebase/remote-config-compat": "0.2.9",
-        "@firebase/app-compat": "0.2.43",
-        "@firebase/performance": "0.6.9",
-        "@firebase/app-types": "0.9.2",
-        "@firebase/database": "1.0.8",
-        "@firebase/installations-compat": "0.2.9",
-        "@firebase/remote-config": "0.4.9",
-        "@firebase/database-compat": "1.0.8",
-        "@firebase/functions": "0.11.8",
-        "@firebase/app-check-compat": "0.3.15",
-        "@firebase/messaging-compat": "0.2.12"
+        "@firebase/analytics": "0.10.12",
+        "@firebase/messaging": "0.12.17",
+        "@firebase/analytics-compat": "0.2.18",
+        "@firebase/auth": "1.9.1",
+        "@firebase/firestore": "4.7.9",
+        "@firebase/installations": "0.6.13",
+        "@firebase/app": "0.11.2",
+        "@firebase/app-check": "0.8.12",
+        "@firebase/data-connect": "0.3.1",
+        "@firebase/functions-compat": "0.3.20",
+        "@firebase/auth-compat": "0.5.19",
+        "@firebase/performance-compat": "0.2.14",
+        "@firebase/vertexai": "1.1.0",
+        "@firebase/storage": "0.13.7",
+        "@firebase/firestore-compat": "0.3.44",
+        "@firebase/util": "1.11.0",
+        "@firebase/storage-compat": "0.3.17",
+        "@firebase/remote-config-compat": "0.2.13",
+        "@firebase/app-compat": "0.2.51",
+        "@firebase/performance": "0.7.1",
+        "@firebase/app-types": "0.9.3",
+        "@firebase/database": "1.0.13",
+        "@firebase/installations-compat": "0.2.13",
+        "@firebase/remote-config": "0.6.0",
+        "@firebase/database-compat": "2.0.4",
+        "@firebase/functions": "0.12.3",
+        "@firebase/app-check-compat": "0.3.19",
+        "@firebase/messaging-compat": "0.2.17"
       }
     },
     "node_modules/lru-memoizer": {
@@ -6487,18 +6443,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/jwks-rsa/node_modules/@types/express-serve-static-core": {
-      "version": "4.19.6",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
-      "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*",
-        "@types/send": "*"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -6527,18 +6471,6 @@
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
-    },
-    "node_modules/jwks-rsa/node_modules/@types/express": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
-      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.33",
-        "@types/qs": "*",
-        "@types/serve-static": "*"
-      }
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -6633,7 +6565,6 @@
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
       "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "jwa": "^2.0.0",
         "safe-buffer": "^5.0.1"
@@ -6659,28 +6590,6 @@
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
-      }
-    },
-    "node_modules/@firebase/vertexai-preview": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@firebase/vertexai-preview/-/vertexai-preview-0.0.4.tgz",
-      "integrity": "sha512-EBSqyu9eg8frQlVU9/HjKtHN7odqbh9MtAcVz3WwHj4gLCLOoN9F/o+oxlq3CxvFrd3CNTZwu6d2mZtVlEInng==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@firebase/app-check-interop-types": "0.3.2",
-        "@firebase/component": "0.6.9",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.10.0",
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@firebase/app": "0.x",
-        "@firebase/app-types": "0.x"
       }
     },
     "node_modules/array-flatten": {
@@ -6736,8 +6645,8 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -6776,17 +6685,17 @@
       }
     },
     "node_modules/@firebase/installations-compat": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.9.tgz",
-      "integrity": "sha512-2lfdc6kPXR7WaL4FCQSQUhXcPbI7ol3wF+vkgtU25r77OxPf8F/VmswQ7sgIkBBWtymn5ZF20TIKtnOj9rjb6w==",
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.13.tgz",
+      "integrity": "sha512-f/o6MqCI7LD/ulY9gvgkv6w5k6diaReD8BFHd/y/fEdpsXmFWYS/g28GXCB72bRVBOgPpkOUNl+VsMvDwlRKmw==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@firebase/component": "0.6.9",
-        "@firebase/installations": "0.6.9",
-        "@firebase/installations-types": "0.5.2",
-        "@firebase/util": "1.10.0",
+        "@firebase/component": "0.6.13",
+        "@firebase/installations": "0.6.13",
+        "@firebase/installations-types": "0.5.3",
+        "@firebase/util": "1.11.0",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -6821,7 +6730,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
@@ -6925,18 +6833,20 @@
       }
     },
     "node_modules/@firebase/auth": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.7.9.tgz",
-      "integrity": "sha512-yLD5095kVgDw965jepMyUrIgDklD6qH/BZNHeKOgvu7pchOKNjVM+zQoOVYJIKWMWOWBq8IRNVU6NXzBbozaJg==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.9.1.tgz",
+      "integrity": "sha512-9KKo5SNVkyJzftsW+daS+PGDbeJ+MFJWXQFHDqqPPH3acWHtiNnGHH5HGpIJErEELrsm9xMPie5zfZ0XpGU8+w==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@firebase/component": "0.6.9",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.10.0",
-        "tslib": "^2.1.0",
-        "undici": "6.19.7"
+        "@firebase/component": "0.6.13",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.11.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "@firebase/app": "0.x",
@@ -6947,6 +6857,14 @@
           "optional": true
         }
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
+      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
@@ -7067,8 +6985,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -7165,31 +7083,20 @@
       }
     },
     "node_modules/@firebase/installations": {
-      "version": "0.6.9",
-      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.9.tgz",
-      "integrity": "sha512-hlT7AwCiKghOX3XizLxXOsTFiFCQnp/oj86zp1UxwDGmyzsyoxtX+UIZyVyH/oBF5+XtblFG9KZzZQ/h+dpy+Q==",
+      "version": "0.6.13",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.13.tgz",
+      "integrity": "sha512-6ZpkUiaygPFwgVneYxuuOuHnSPnTA4KefLEaw/sKk/rNYgC7X6twaGfYb0sYLpbi9xV4i5jXsqZ3WO+yaguNgg==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@firebase/component": "0.6.9",
-        "@firebase/util": "1.10.0",
+        "@firebase/component": "0.6.13",
+        "@firebase/util": "1.11.0",
         "idb": "7.1.1",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
         "@firebase/app": "0.x"
-      }
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.4.tgz",
-      "integrity": "sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^3.0.0"
       }
     },
     "node_modules/browserslist": {
@@ -7256,7 +7163,6 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
       "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 14"
       }
@@ -7282,9 +7188,9 @@
       "license": "MIT"
     },
     "node_modules/@firebase/auth-types": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.12.2.tgz",
-      "integrity": "sha512-qsEBaRMoGvHO10unlDJhaKSuPn4pyoTtlQuP1ghZfzB6rNQPuhp/N/DcFZxm9i4v0SogjCbf9reWupwIvfmH6w==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.13.0.tgz",
+      "integrity": "sha512-S/PuIjni0AQRLF+l9ck0YpsMOdE8GO2KU6ubmBB7P+7TJUCQDa3R1dlgYm9UzGbbePMZsp0xzB93f2b/CgxMOg==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -7363,17 +7269,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/undici": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.7.tgz",
-      "integrity": "sha512-HR3W/bMGPSr90i8AAp2C4DM3wChFdJPLrWYpIS++LxS8K+W535qftjt+4MyjNYHeWabMj1nvtmLIi7l++iq91A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=18.17"
-      }
-    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -7442,13 +7337,13 @@
       }
     },
     "node_modules/@firebase/database-types": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.5.tgz",
-      "integrity": "sha512-fTlqCNwFYyq/C6W7AJ5OCuq5CeZuBEsEwptnVxlNPkWCo5cTTyukzAHRSO/jaQcItz33FfYrrFk1SJofcu2AaQ==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.9.tgz",
+      "integrity": "sha512-uCntrxPbJHhZsNRpMhxNCm7GzhYWX+7J2e57wq1ZZ4NJrQw5DORgkAzJMByYZcVAjgADnCxxhK/GkoypH+XpvQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app-types": "0.9.2",
-        "@firebase/util": "1.10.0"
+        "@firebase/app-types": "0.9.3",
+        "@firebase/util": "1.11.0"
       }
     },
     "node_modules/idb": {
@@ -7463,7 +7358,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "devOptional": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/esprima": {
@@ -7608,7 +7502,6 @@
       "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
       "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "gaxios": "^6.0.0",
         "jws": "^4.0.0"
@@ -7883,9 +7776,9 @@
       "license": "MIT"
     },
     "node_modules/@firebase/remote-config-types": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.3.2.tgz",
-      "integrity": "sha512-0BC4+Ud7y2aPTyhXJTMTFfrGGLqdYXrUB9sJVAB8NiqJswDTc4/2qrE/yfUbnQJhbSi6ZaTTBKyG3n1nplssaA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.4.0.tgz",
+      "integrity": "sha512-7p3mRE/ldCNYt8fmWMQ/MSGRmXYlJ15Rvs9Rk17t8p0WwZDbeK7eRmoI1tvCPaDzn9Oqh+yD6Lw+sGLsLg4kKg==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true
@@ -8010,17 +7903,20 @@
       }
     },
     "node_modules/@firebase/database-compat": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-1.0.8.tgz",
-      "integrity": "sha512-OpeWZoPE3sGIRPBKYnW9wLad25RaWbGyk7fFQe4xnJQKRzlynWeFBSRRAoLE2Old01WXwskUiucNqUUVlFsceg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.0.4.tgz",
+      "integrity": "sha512-4qsptwZ3DTGNBje56ETItZQyA/HMalOelnLmkC3eR0M6+zkzOHjNHyWUWodW2mqxRKAM0sGkn+aIwYHKZFJXug==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.9",
-        "@firebase/database": "1.0.8",
-        "@firebase/database-types": "1.0.5",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.10.0",
+        "@firebase/component": "0.6.13",
+        "@firebase/database": "1.0.13",
+        "@firebase/database-types": "1.0.9",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.11.0",
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/buffer-from": {
@@ -8072,18 +7968,21 @@
       }
     },
     "node_modules/@firebase/database": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.8.tgz",
-      "integrity": "sha512-dzXALZeBI1U5TXt6619cv0+tgEhJiwlUtQ55WNZY7vGAjv7Q1QioV969iYwt1AQQ0ovHnEW0YW9TiBfefLvErg==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.13.tgz",
+      "integrity": "sha512-cdc+LuseKdJXzlrCx8ePMXyctSWtYS9SsP3y7EeA85GzNh/IL0b7HOq0eShridL935iQ0KScZCj5qJtKkGE53g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app-check-interop-types": "0.3.2",
-        "@firebase/auth-interop-types": "0.2.3",
-        "@firebase/component": "0.6.9",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.10.0",
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.6.13",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.11.0",
         "faye-websocket": "0.11.4",
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/fast-json-stable-stringify": {
@@ -8205,9 +8104,9 @@
       }
     },
     "node_modules/@firebase/analytics-types": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.2.tgz",
-      "integrity": "sha512-EnzNNLh+9/sJsimsA/FGqzakmrAUKLeJvjRHlg8df1f97NLUlFidk9600y0ZgWOp3CAxn6Hjtk+08tixlUOWyw==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.3.tgz",
+      "integrity": "sha512-VrIp/d8iq2g501qO46uGz3hjbDb8xzYMrbu8Tp0ovzIzrvJZ2fvmj649gTjge/b7cCCcjT0H37g1gVtlNhnkbg==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true
@@ -8243,15 +8142,15 @@
       "license": "MIT"
     },
     "node_modules/firebase-functions": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-5.1.1.tgz",
-      "integrity": "sha512-KkyKZE98Leg/C73oRyuUYox04PQeeBThdygMfeX+7t1cmKWYKa/ZieYa89U8GHgED+0mF7m7wfNZOfbURYxIKg==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-6.3.2.tgz",
+      "integrity": "sha512-FC3A1/nhqt1ZzxRnj5HZLScQaozAcFSD/vSR8khqSoFNOfxuXgwJS6ZABTB7+v+iMD5z6Mmxw6OfqITUBuI7OQ==",
       "license": "MIT",
       "dependencies": {
         "@types/cors": "^2.8.5",
-        "@types/express": "4.17.3",
+        "@types/express": "^4.17.21",
         "cors": "^2.8.5",
-        "express": "^4.17.1",
+        "express": "^4.21.0",
         "protobufjs": "^7.2.2"
       },
       "bin": {
@@ -8261,13 +8160,13 @@
         "node": ">=14.10.0"
       },
       "peerDependencies": {
-        "firebase-admin": "^11.10.0 || ^12.0.0"
+        "firebase-admin": "^11.10.0 || ^12.0.0 || ^13.0.0"
       }
     },
     "node_modules/@firebase/webchannel-wrapper": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.1.tgz",
-      "integrity": "sha512-jmEnr/pk0yVkA7mIlHNnxCi+wWzOFUg0WyIotgkKAb2u1J7fAeDBcVNSTjTihbAYNusCLQdW5s9IJ5qwnEufcQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.3.tgz",
+      "integrity": "sha512-2xCRM9q9FlzGZCdgDMJwc0gyUkWFtkosy7Xxr6sFgQwn+wMNIWd7xIvYNauU1r64B5L5rsGKy/n9TKJ0aAFeqQ==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true
@@ -8519,17 +8418,19 @@
       }
     },
     "node_modules/@firebase/storage": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.13.2.tgz",
-      "integrity": "sha512-fxuJnHshbhVwuJ4FuISLu+/76Aby2sh+44ztjF2ppoe0TELIDxPW6/r1KGlWYt//AD0IodDYYA8ZTN89q8YqUw==",
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.13.7.tgz",
+      "integrity": "sha512-FkRyc24rK+Y6EaQ1tYFm3TevBnnfSNA0VyTfew2hrYyL/aYfatBg7HOgktUdB4kWMHNA9VoTotzZTGoLuK92wg==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@firebase/component": "0.6.9",
-        "@firebase/util": "1.10.0",
-        "tslib": "^2.1.0",
-        "undici": "6.19.7"
+        "@firebase/component": "0.6.13",
+        "@firebase/util": "1.11.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "@firebase/app": "0.x"
@@ -8571,9 +8472,9 @@
       "license": "ISC"
     },
     "node_modules/@firebase/app-check-interop-types": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.2.tgz",
-      "integrity": "sha512-LMs47Vinv2HBMZi49C09dJxp0QT5LwDzFaVGf/+ITHe3BlIhUiLNttkATSXplc89A2lAaeTqjgqVkiRfUGyQiQ==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.3.tgz",
+      "integrity": "sha512-gAlxfPLT2j8bTI/qfe3ahl2I2YcBQ8cFIBdhAQA4I2f3TndcO+22YizyGYuttLHPQEpWkhmpFW60VCFEPg4g5A==",
       "license": "Apache-2.0"
     },
     "node_modules/finalhandler": {
@@ -8702,27 +8603,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/gaxios/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/type-fest": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
@@ -8768,6 +8648,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@firebase/vertexai": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@firebase/vertexai/-/vertexai-1.1.0.tgz",
+      "integrity": "sha512-K8CgIFKJrfrf5lYhKnDXOu08FEmIzVExK+ApUZx4Bw2GAmLEA3wDVrsjuupuvpXZSp8QlzvEiXwqshqqc4v0pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/component": "0.6.13",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.11.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-types": "0.x"
       }
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -8816,18 +8718,21 @@
       }
     },
     "node_modules/@firebase/functions-compat": {
-      "version": "0.3.14",
-      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.3.14.tgz",
-      "integrity": "sha512-dZ0PKOKQFnOlMfcim39XzaXonSuPPAVuzpqA4ONTIdyaJK/OnBaIEVs/+BH4faa1a2tLeR+Jy15PKqDRQoNIJw==",
+      "version": "0.3.20",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.3.20.tgz",
+      "integrity": "sha512-iIudmYDAML6n3c7uXO2YTlzra2/J6lnMzmJTXNthvrKVMgNMaseNoQP1wKfchK84hMuSF8EkM4AvufwbJ+Juew==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@firebase/component": "0.6.9",
-        "@firebase/functions": "0.11.8",
-        "@firebase/functions-types": "0.6.2",
-        "@firebase/util": "1.10.0",
+        "@firebase/component": "0.6.13",
+        "@firebase/functions": "0.12.3",
+        "@firebase/functions-types": "0.6.3",
+        "@firebase/util": "1.11.0",
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "@firebase/app-compat": "0.x"
@@ -8862,9 +8767,9 @@
       }
     },
     "node_modules/@firebase/installations-types": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.2.tgz",
-      "integrity": "sha512-que84TqGRZJpJKHBlF2pkvc1YcXrtEDOVGiDjovP/a3s6W4nlbohGXEsBJo0JCeeg/UG9A+DEZVDUV9GpklUzA==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.3.tgz",
+      "integrity": "sha512-2FJI7gkLqIE0iYsNQ1P751lO3hER+Umykel+TkLwHj6plzWVxqvfclPUZhcKFVQObqloEBTmpi2Ozn7EkCABAA==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -9448,9 +9353,9 @@
       }
     },
     "node_modules/@firebase/firestore-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.2.tgz",
-      "integrity": "sha512-wp1A+t5rI2Qc/2q7r2ZpjUXkRVPtGMd6zCLsiWurjsQpqPgFin3AhNibKcIzoF2rnToNa/XYtyWXuifjOOwDgg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.3.tgz",
+      "integrity": "sha512-hD2jGdiWRxB/eZWF89xcK9gF8wvENDJkzpVFb4aGkzfEaKxVRD1kjz1t1Wj8VZEp2LCB53Yx1zD8mrhQu87R6Q==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -9614,17 +9519,17 @@
       }
     },
     "node_modules/@firebase/remote-config": {
-      "version": "0.4.9",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.4.9.tgz",
-      "integrity": "sha512-EO1NLCWSPMHdDSRGwZ73kxEEcTopAxX1naqLJFNApp4hO8WfKfmEpmjxmP5TrrnypjIf2tUkYaKsfbEA7+AMmA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.6.0.tgz",
+      "integrity": "sha512-Yrk4l5+6FJLPHC6irNHMzgTtJ3NfHXlAXVChCBdNFtgmzyGmufNs/sr8oA0auEfIJ5VpXCaThRh3P4OdQxiAlQ==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@firebase/component": "0.6.9",
-        "@firebase/installations": "0.6.9",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.10.0",
+        "@firebase/component": "0.6.13",
+        "@firebase/installations": "0.6.13",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.11.0",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -9712,19 +9617,20 @@
       "license": "0BSD"
     },
     "node_modules/form-data": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.3.tgz",
-      "integrity": "sha512-q5YBMeWy6E2Un0nMGWMgI65MAKtaylxfNJGJxpGh45YDciZB4epbWpaAfImil6CPAPTYB4sh0URQNDRIZG5F2w==",
-      "dev": true,
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.3.tgz",
+      "integrity": "sha512-XHIrMD0NpDrNM/Ckf7XJiBbLl57KEhT3+i3yY+eWm+cqYZJQTZrKo8Y8AWKnuV5GT4scfuUGt9LzNoIx3dU1nQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "mime-types": "^2.1.35"
+        "mime-types": "^2.1.35",
+        "safe-buffer": "^5.2.1"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 0.12"
       }
     },
     "node_modules/which": {
@@ -9744,9 +9650,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.4.0.tgz",
+      "integrity": "sha512-4tv8DA1nBRW5kF2KBJZzEBjd66kDf3jArNVPoktdlv9Xsgw7EcIMu1bVbAXbX5IWuuZZ3YW3jIM2x85SPgMP6w==",
       "license": "MIT"
     },
     "node_modules/string.prototype.trimend": {
@@ -9882,7 +9788,6 @@
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
       "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
@@ -9895,9 +9800,9 @@
       }
     },
     "node_modules/@firebase/app-types": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.2.tgz",
-      "integrity": "sha512-oMEZ1TDlBz479lmABwWsWjzHwheQKiAgnuKxE0pz0IXCVx7/rtlkx1fQ6GfgK24WCrxDKMplZrT50Kh04iMbXQ==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
+      "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
       "license": "Apache-2.0"
     },
     "node_modules/make-error": {
@@ -9921,7 +9826,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9931,17 +9835,17 @@
       }
     },
     "node_modules/@firebase/messaging": {
-      "version": "0.12.12",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.12.tgz",
-      "integrity": "sha512-6q0pbzYBJhZEtUoQx7hnPhZvAbuMNuBXKQXOx2YlWhSrlv9N1m0ZzlNpBbu/ItTzrwNKTibdYzUyaaxdWLg+4w==",
+      "version": "0.12.17",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.17.tgz",
+      "integrity": "sha512-W3CnGhTm6Nx8XGb6E5/+jZTuxX/EK8Vur4QXvO1DwZta/t0xqWMRgO9vNsZFMYBqFV4o3j4F9qK/iddGYwWS6g==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@firebase/component": "0.6.9",
-        "@firebase/installations": "0.6.9",
-        "@firebase/messaging-interop-types": "0.2.2",
-        "@firebase/util": "1.10.0",
+        "@firebase/component": "0.6.13",
+        "@firebase/installations": "0.6.13",
+        "@firebase/messaging-interop-types": "0.2.3",
+        "@firebase/util": "1.11.0",
         "idb": "7.1.1",
         "tslib": "^2.1.0"
       },
@@ -10132,13 +10036,16 @@
       }
     },
     "node_modules/@firebase/component": {
-      "version": "0.6.9",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.9.tgz",
-      "integrity": "sha512-gm8EUEJE/fEac86AvHn8Z/QW8BvR56TBw3hMW0O838J/1mThYQXAIQBgUv75EqlCZfdawpWLrKt1uXvp9ciK3Q==",
+      "version": "0.6.13",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.13.tgz",
+      "integrity": "sha512-I/Eg1NpAtZ8AAfq8mpdfXnuUpcLxIDdCDtTzWSh+FXnp/9eCKJ3SNbOCKrUCyhLzNa2SiPJYruei0sxVjaOTeg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/util": "1.10.0",
+        "@firebase/util": "1.11.0",
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/prelude-ls": {
@@ -10169,17 +10076,17 @@
       "optional": true
     },
     "node_modules/@firebase/analytics": {
-      "version": "0.10.8",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.8.tgz",
-      "integrity": "sha512-CVnHcS4iRJPqtIDc411+UmFldk0ShSK3OB+D0bKD8Ck5Vro6dbK5+APZpkuWpbfdL359DIQUnAaMLE+zs/PVyA==",
+      "version": "0.10.12",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.12.tgz",
+      "integrity": "sha512-iDCGnw6qdFqwI5ywkgece99WADJNoymu+nLIQI4fZM/vCZ3bEo4wlpEetW71s1HqGpI0hQStiPhqVjFxDb2yyw==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@firebase/component": "0.6.9",
-        "@firebase/installations": "0.6.9",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.10.0",
+        "@firebase/component": "0.6.13",
+        "@firebase/installations": "0.6.13",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.11.0",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -21,14 +21,14 @@
   "dependencies": {
     "express": "^4.21.1",
     "fast-deep-equal": "^3.1.3",
-    "firebase-admin": "^12.3.0",
-    "firebase-functions": "^5.0.1",
+    "firebase-admin": "^13.2.0",
+    "firebase-functions": "^6.3.2",
     "moment": "^2.29.1",
     "njwt": "^2.0.1",
     "typescript": "^4.9.5"
   },
   "devDependencies": {
-    "@firebase/rules-unit-testing": "^3.0.4",
+    "@firebase/rules-unit-testing": "^4.0.1",
     "@types/jest": "^27.4.1",
     "@typescript-eslint/eslint-plugin": "^3.9.1",
     "@typescript-eslint/parser": "^3.8.0",
@@ -36,10 +36,13 @@
     "eslint": "^7.6.0",
     "eslint-config-google": "^0.14.0",
     "eslint-plugin-import": "^2.22.0",
-    "firebase-functions-test": "^3.3.0",
+    "firebase-functions-test": "^3.4.1",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1"
   },
-  "private": true
+  "private": true,
+  "overrides": {
+    "undici-types": "7.4.0"
+  }
 }

--- a/functions/src/error-handler.ts
+++ b/functions/src/error-handler.ts
@@ -1,5 +1,6 @@
 import { ExtensionError, InvalidApiVersionError, InvalidTokenError, UnknownError } from "./exceptions";
-import { logger, Response } from "firebase-functions";
+import { logger } from "firebase-functions";
+import { Response } from "express";
 
 interface ErrorPayload {
     code: number,

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -28,7 +28,7 @@ const CUSTOMERS_COLLECTION = process.env.REVENUECAT_CUSTOMERS_COLLECTION as
 const SET_CUSTOM_CLAIMS = process.env.SET_CUSTOM_CLAIMS as
   | "ENABLED"
   | "DISABLED";
-const EXTENSION_VERSION = process.env.EXTENSION_VERSION || "0.1.16";
+const EXTENSION_VERSION = process.env.EXTENSION_VERSION || "0.1.17";
 
 const getCustomersCollection = ({
   firestore,


### PR DESCRIPTION
We need to update several libraries, primarily because we are using an outdated admin library, which is causing permission issues when setting claims (see [this issue](https://github.com/firebase/firebase-tools/issues/7209)).

Additionally, to prevent security vulnerabilities in the `undici-types` library, we are forcing it to use a more up-to-date version. However, we cannot simply install the latest version directly, as an older version is still required by `@types/node`.

Also, bumping version to 0.1.17